### PR TITLE
feat(kyc): employee KYC fields + document vault with Cloudinary uploads

### DIFF
--- a/API_DOCS.md
+++ b/API_DOCS.md
@@ -220,6 +220,9 @@ All staff endpoints require `AuthMiddleware` + `TenantMiddleware`. Every employe
 | `PUT` | `/api/v1/staff/{id}` | `staffCtrl.Update` | Update employee (blocks "employee" role) |
 | `DELETE` | `/api/v1/staff/{id}` | `staffCtrl.Delete` | Soft-delete (requires "owner" role) |
 | `POST` | `/api/v1/staff/{id}/upload-photo` | `uploadCtrl.UploadPhoto` | Upload photo (jpg/png, max 5MB) |
+| `GET` | `/api/v1/staff/{id}/documents` | `uploadCtrl.ListDocuments` | List KYC documents for employee |
+| `POST` | `/api/v1/staff/{id}/documents/{type}` | `uploadCtrl.UploadDocument` | Upload/replace KYC doc (aadhaar\|pan\|bank, jpg/png/pdf) |
+| `DELETE` | `/api/v1/staff/{id}/documents/{type}` | `uploadCtrl.DeleteDocument` | Delete KYC doc + stored asset |
 | `GET` | `/api/v1/staff/{id}/profile` | `staffCtrl.Profile` | Full profile with manager + shift info |
 | `PUT` | `/api/v1/staff/{id}/manager` | `staffCtrl.AssignManager` | Set/remove reporting manager |
 
@@ -255,19 +258,26 @@ All staff endpoints require `AuthMiddleware` + `TenantMiddleware`. Every employe
 {
   "name": "Rahul Sharma", "phone": "+919876543210",
   "designation": "Operator", "wage_type": "daily", "wage_amount": "450",
-  "daily_target_units": 100
+  "daily_target_units": 100,
+  "date_of_joining": "2024-01-15", "pan_number": "ABCDE1234F",
+  "aadhaar_number": "123412341234", "pf_number": "MH/123/4567",
+  "bank_account_number": "00012345678901", "bank_ifsc": "SBIN0001234",
+  "upi_id": "rahul@upi", "emergency_contact_name": "Sunita",
+  "emergency_contact_phone": "+919000000000", "health_notes": "None",
+  "current_address": "Line 1, City", "permanent_address": "Village, Dist"
 }
 ```
 **Required:** `name`, `phone`, `wage_type`, `wage_amount`
+**Optional KYC:** `date_of_joining`, `pan_number`, `aadhaar_number`, `pf_number`, `bank_account_number`, `bank_ifsc`, `upi_id`, `emergency_contact_name`, `emergency_contact_phone`, `health_notes`, `current_address`, `permanent_address`
 
-**Frontend**: `StaffService.create()` → `AddEmployeeScreen` (premium form with wage type toggle, haptic feedback, glassmorphism fields).
+**Frontend**: `StaffService.create()` → `AddEmployeeScreen` (premium form with wage type toggle, KYC & Financial section, Emergency & Address section, haptic feedback, glassmorphism fields).
 
 ---
 
 #### `GET /api/v1/staff/{id}`
 
 **Path Param:** `id` — Employee UUID
-**Success:** Single employee object (same shape as list items).
+**Success:** Single employee object (same shape as list items, including all KYC fields).
 
 **Frontend**: `StaffService.get()` → `EmployeeProfileScreen` (fetched in `initState`).
 
@@ -275,8 +285,8 @@ All staff endpoints require `AuthMiddleware` + `TenantMiddleware`. Every employe
 
 #### `PUT /api/v1/staff/{id}`
 
-**Request:** Same shape as create. **Blocks "employee" role** (403).
-**Frontend**: Not yet wired (future: edit employee from profile screen).
+**Request:** Same shape as create. KYC fields are only updated when provided; `null`/omitted values keep the existing value. **Blocks "employee" role** (403).
+**Frontend**: `StaffService.update()` → `AddEmployeeScreen` opened in edit mode from profile screen.
 
 ---
 
@@ -290,7 +300,7 @@ Soft-deletes (`is_active = false`). **Requires "owner" role** (403 otherwise).
 #### `POST /api/v1/staff/{id}/upload-photo`
 
 **Multipart:** `file` field, max 5MB, `.jpg`/`.jpeg`/`.png` only.
-Saves to `./uploads/{employeeID}-{random}{ext}`. Updates `photo_url` on employee record.
+When Cloudinary is configured (`CLOUDINARY_CLOUD_NAME` + `CLOUDINARY_API_KEY` + `CLOUDINARY_API_SECRET`), the photo is uploaded to the `profiles` folder and `photo_url` is the Cloudinary `secure_url`. Otherwise it is saved to `./uploads/{employeeID}-{random}{ext}` and `photo_url` is `/uploads/{filename}`.
 
 **Success:**
 ```json
@@ -298,6 +308,34 @@ Saves to `./uploads/{employeeID}-{random}{ext}`. Updates `photo_url` on employee
 ```
 
 **Frontend**: Not yet wired.
+
+---
+
+#### `POST /api/v1/staff/{id}/documents/{type}`
+
+**Path:** `type` must be `aadhaar`, `pan`, or `bank` (one slot per type — uploading replaces).
+**Multipart:** `file` field, max 5MB, `.jpg`/`.jpeg`/`.png`/`.pdf` only.
+**Blocks "employee" role** (403). Stored in Cloudinary (`kyc/{employeeID}` folder, deterministic public id) when configured; otherwise `./uploads/`.
+Deletes the previous asset when replacing.
+
+**Success:**
+```json
+{ "status": "success", "data": { "id": "uuid", "doc_type": "aadhaar", "file_path": "https://res.cloudinary.com/.../kyc/abc/aadhaar.jpg", "public_id": "kyc/abc/aadhaar", "original_name": "aadhaar.jpg" } }
+```
+
+---
+
+#### `GET /api/v1/staff/{id}/documents`
+
+Returns array of `{ id, doc_type, file_path, public_id, original_name, uploaded_at }` for the employee.
+
+---
+
+#### `DELETE /api/v1/staff/{id}/documents/{type}`
+
+Deletes the document record and removes the stored asset (Cloudinary destroy or local file). **Blocks "employee" role** (403). Returns 404 if no document exists.
+
+**Frontend**: `DocumentService` → `_DocumentVault` in `EmployeeProfileScreen` Info & KYC tab (3 cards: Aadhaar / PAN / Bank Passbook, camera/gallery/PDF picker, thumbnail, view, delete).
 
 ---
 

--- a/app/ios/Runner/Info.plist
+++ b/app/ios/Runner/Info.plist
@@ -26,6 +26,12 @@
 	<string>$(FLUTTER_BUILD_NUMBER)</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
+	<key>NSCameraUsageDescription</key>
+	<string>Camera is used to capture employee profile photos and KYC documents (Aadhaar, PAN, bank passbook).</string>
+	<key>NSPhotoLibraryUsageDescription</key>
+	<string>Photo library access is used to pick existing employee profile photos and KYC documents.</string>
+	<key>NSMicrophoneUsageDescription</key>
+	<string>Microphone access may be requested by the camera when capturing KYC documents.</string>
 	<key>UIApplicationSceneManifest</key>
 	<dict>
 		<key>UIApplicationSupportsMultipleScenes</key>

--- a/app/lib/core/api_client.dart
+++ b/app/lib/core/api_client.dart
@@ -69,6 +69,23 @@ class ApiClient {
     return _handle(await http.delete(uri, headers: _headers).timeout(_timeout));
   }
 
+  Future<Map<String, dynamic>> postMultipart(
+    String path, {
+    required List<http.MultipartFile> files,
+    Map<String, String>? fields,
+  }) async {
+    final uri = Uri.parse('$baseUrl$path');
+    final req = http.MultipartRequest('POST', uri);
+    if (_token != null) {
+      req.headers['Authorization'] = 'Bearer $_token';
+    }
+    if (fields != null) req.fields.addAll(fields);
+    req.files.addAll(files);
+    final streamed = await req.send().timeout(_timeout);
+    final res = await http.Response.fromStream(streamed);
+    return _handle(res);
+  }
+
   Map<String, dynamic> _handle(http.Response response) {
     final json = jsonDecode(response.body) as Map<String, dynamic>;
     if (response.statusCode >= 200 && response.statusCode < 300) {

--- a/app/lib/core/widgets/validated_field.dart
+++ b/app/lib/core/widgets/validated_field.dart
@@ -8,6 +8,7 @@ class ValidatedField extends StatefulWidget {
   final IconData? prefixIcon;
   final TextInputType? keyboardType;
   final bool enabled;
+  final bool readOnly;
   final bool obscureText;
   final int? maxLines;
   final String? Function(String?)? validator;
@@ -21,6 +22,7 @@ class ValidatedField extends StatefulWidget {
     this.prefixIcon,
     this.keyboardType,
     this.enabled = true,
+    this.readOnly = false,
     this.obscureText = false,
     this.maxLines,
     this.validator,
@@ -111,6 +113,7 @@ class _ValidatedFieldState extends State<ValidatedField> {
                   focusNode: _focusNode,
                   keyboardType: widget.keyboardType,
                   enabled: widget.enabled,
+                  readOnly: widget.readOnly,
                   obscureText: widget.obscureText,
                   maxLines: widget.maxLines,
                   style: tt.bodyLarge?.copyWith(

--- a/app/lib/features/staff/add_employee_page.dart
+++ b/app/lib/features/staff/add_employee_page.dart
@@ -22,6 +22,18 @@ class _AddEmployeeScreenState extends ConsumerState<AddEmployeeScreen> {
   final _phoneCtrl = TextEditingController();
   final _desigCtrl = TextEditingController();
   final _wageCtrl = TextEditingController();
+  final _dojCtrl = TextEditingController();
+  final _panCtrl = TextEditingController();
+  final _aadhaarCtrl = TextEditingController();
+  final _pfCtrl = TextEditingController();
+  final _bankCtrl = TextEditingController();
+  final _ifscCtrl = TextEditingController();
+  final _upiCtrl = TextEditingController();
+  final _emergencyNameCtrl = TextEditingController();
+  final _emergencyPhoneCtrl = TextEditingController();
+  final _healthCtrl = TextEditingController();
+  final _currentAddrCtrl = TextEditingController();
+  final _permAddrCtrl = TextEditingController();
   late String _wageType;
   late String _role;
   bool _saving = false;
@@ -38,6 +50,18 @@ class _AddEmployeeScreenState extends ConsumerState<AddEmployeeScreen> {
       _phoneCtrl.text = e.phone;
       _desigCtrl.text = e.designation ?? '';
       _wageCtrl.text = e.wageAmount == 0 ? '' : e.wageAmount.toStringAsFixed(0);
+      _dojCtrl.text = e.dateOfJoining ?? '';
+      _panCtrl.text = e.panNumber ?? '';
+      _aadhaarCtrl.text = e.aadhaarNumber ?? '';
+      _pfCtrl.text = e.pfNumber ?? '';
+      _bankCtrl.text = e.bankAccountNumber ?? '';
+      _ifscCtrl.text = e.bankIfsc ?? '';
+      _upiCtrl.text = e.upiId ?? '';
+      _emergencyNameCtrl.text = e.emergencyContactName ?? '';
+      _emergencyPhoneCtrl.text = e.emergencyContactPhone ?? '';
+      _healthCtrl.text = e.healthNotes ?? '';
+      _currentAddrCtrl.text = e.currentAddress ?? '';
+      _permAddrCtrl.text = e.permanentAddress ?? '';
       _wageType = e.wageType;
       _role = e.role;
       _selectedShiftId = e.defaultShiftId;
@@ -60,6 +84,18 @@ class _AddEmployeeScreenState extends ConsumerState<AddEmployeeScreen> {
     _phoneCtrl.dispose();
     _desigCtrl.dispose();
     _wageCtrl.dispose();
+    _dojCtrl.dispose();
+    _panCtrl.dispose();
+    _aadhaarCtrl.dispose();
+    _pfCtrl.dispose();
+    _bankCtrl.dispose();
+    _ifscCtrl.dispose();
+    _upiCtrl.dispose();
+    _emergencyNameCtrl.dispose();
+    _emergencyPhoneCtrl.dispose();
+    _healthCtrl.dispose();
+    _currentAddrCtrl.dispose();
+    _permAddrCtrl.dispose();
     super.dispose();
   }
 
@@ -91,6 +127,18 @@ class _AddEmployeeScreenState extends ConsumerState<AddEmployeeScreen> {
         'wage_type': _wageType,
         'wage_amount': _wageCtrl.text.trim().isEmpty ? '0' : _wageCtrl.text.trim(),
         'role': _role,
+        'date_of_joining': _dojCtrl.text.trim().isEmpty ? null : _dojCtrl.text.trim(),
+        'pan_number': _panCtrl.text.trim().isEmpty ? null : _panCtrl.text.trim(),
+        'aadhaar_number': _aadhaarCtrl.text.trim().isEmpty ? null : _aadhaarCtrl.text.trim(),
+        'pf_number': _pfCtrl.text.trim().isEmpty ? null : _pfCtrl.text.trim(),
+        'bank_account_number': _bankCtrl.text.trim().isEmpty ? null : _bankCtrl.text.trim(),
+        'bank_ifsc': _ifscCtrl.text.trim().isEmpty ? null : _ifscCtrl.text.trim(),
+        'upi_id': _upiCtrl.text.trim().isEmpty ? null : _upiCtrl.text.trim(),
+        'emergency_contact_name': _emergencyNameCtrl.text.trim().isEmpty ? null : _emergencyNameCtrl.text.trim(),
+        'emergency_contact_phone': _emergencyPhoneCtrl.text.trim().isEmpty ? null : _emergencyPhoneCtrl.text.trim(),
+        'health_notes': _healthCtrl.text.trim().isEmpty ? null : _healthCtrl.text.trim(),
+        'current_address': _currentAddrCtrl.text.trim().isEmpty ? null : _currentAddrCtrl.text.trim(),
+        'permanent_address': _permAddrCtrl.text.trim().isEmpty ? null : _permAddrCtrl.text.trim(),
       };
       final e = widget.employee;
       if (e != null) {
@@ -116,6 +164,19 @@ class _AddEmployeeScreenState extends ConsumerState<AddEmployeeScreen> {
   void _updateWage(String type) {
     HapticFeedback.selectionClick();
     setState(() => _wageType = type);
+  }
+
+  Future<void> _pickDoj() async {
+    final now = DateTime.now();
+    final picked = await showDatePicker(
+      context: context,
+      initialDate: _dojCtrl.text.isNotEmpty ? (DateTime.tryParse(_dojCtrl.text) ?? now) : now,
+      firstDate: DateTime(1990),
+      lastDate: now,
+    );
+    if (picked != null) {
+      setState(() => _dojCtrl.text = '${picked.year}-${picked.month.toString().padLeft(2, '0')}-${picked.day.toString().padLeft(2, '0')}');
+    }
   }
 
   @override
@@ -213,6 +274,43 @@ class _AddEmployeeScreenState extends ConsumerState<AddEmployeeScreen> {
                   child: _RoleSelector(role: _role, onChanged: (r) => setState(() => _role = r)),
                 ),
               ],
+              const SizedBox(height: 24),
+              FluidSlideIn(
+                delay: 1100,
+                child: Text('KYC & FINANCIAL', style: tt.labelSmall?.copyWith(fontWeight: FontWeight.w800, color: cs.primary, letterSpacing: 1.0)),
+              ),
+              const SizedBox(height: 16),
+              FluidSlideIn(
+                delay: 1200,
+                child: InkWell(
+                  onTap: _pickDoj,
+                  borderRadius: BorderRadius.circular(16),
+                  child: ValidatedField(
+                    controller: _dojCtrl,
+                    label: 'Date of Joining',
+                    prefixIcon: PhosphorIconsRegular.calendarBlank,
+                    readOnly: true,
+                    hint: 'Tap to select date',
+                  ),
+                ),
+              ),
+              FluidSlideIn(delay: 1300, child: ValidatedField(controller: _panCtrl, label: 'PAN Number', prefixIcon: PhosphorIconsRegular.identificationCard)),
+              FluidSlideIn(delay: 1400, child: ValidatedField(controller: _aadhaarCtrl, label: 'Aadhaar Number', prefixIcon: PhosphorIconsRegular.fingerprint, keyboardType: TextInputType.number)),
+              FluidSlideIn(delay: 1500, child: ValidatedField(controller: _pfCtrl, label: 'PF / UAN Number', prefixIcon: PhosphorIconsRegular.shieldStar)),
+              FluidSlideIn(delay: 1600, child: ValidatedField(controller: _bankCtrl, label: 'Bank Account Number', prefixIcon: PhosphorIconsRegular.bank, keyboardType: TextInputType.number)),
+              FluidSlideIn(delay: 1700, child: ValidatedField(controller: _ifscCtrl, label: 'Bank IFSC', prefixIcon: PhosphorIconsRegular.bank)),
+              FluidSlideIn(delay: 1800, child: ValidatedField(controller: _upiCtrl, label: 'UPI ID', prefixIcon: PhosphorIconsRegular.qrCode)),
+              const SizedBox(height: 24),
+              FluidSlideIn(
+                delay: 1900,
+                child: Text('EMERGENCY & ADDRESS', style: tt.labelSmall?.copyWith(fontWeight: FontWeight.w800, color: cs.primary, letterSpacing: 1.0)),
+              ),
+              const SizedBox(height: 16),
+              FluidSlideIn(delay: 2000, child: ValidatedField(controller: _emergencyNameCtrl, label: 'Emergency Contact Name', prefixIcon: PhosphorIconsRegular.userCircle)),
+              FluidSlideIn(delay: 2100, child: ValidatedField(controller: _emergencyPhoneCtrl, label: 'Emergency Contact Phone', prefixIcon: PhosphorIconsRegular.phone, keyboardType: TextInputType.phone)),
+              FluidSlideIn(delay: 2200, child: ValidatedField(controller: _currentAddrCtrl, label: 'Current Address', prefixIcon: PhosphorIconsRegular.house, maxLines: 2)),
+              FluidSlideIn(delay: 2300, child: ValidatedField(controller: _permAddrCtrl, label: 'Permanent Address', prefixIcon: PhosphorIconsRegular.mapPin, maxLines: 2)),
+              FluidSlideIn(delay: 2400, child: ValidatedField(controller: _healthCtrl, label: 'Health Notes', prefixIcon: PhosphorIconsRegular.firstAid, maxLines: 2)),
             ],
           ),
           Positioned(

--- a/app/lib/features/staff/employee_profile_page.dart
+++ b/app/lib/features/staff/employee_profile_page.dart
@@ -2,6 +2,8 @@ import 'dart:io';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:file_picker/file_picker.dart';
+import 'package:image_picker/image_picker.dart';
 import 'package:path_provider/path_provider.dart';
 import 'package:phosphoricons_flutter/phosphoricons_flutter.dart';
 import '../../providers/providers.dart';
@@ -227,7 +229,7 @@ class _EmployeeProfileScreenState
               controller: _tabCtrl,
               physics: const BouncingScrollPhysics(),
               children: [
-                _InfoTab(cs: cs, tt: tt, profile: _profile),
+                _InfoTab(cs: cs, tt: tt, profile: _profile, employeeId: widget.employeeId),
                 _AttendanceTab(cs: cs, tt: tt, attendanceList: _attendance),
                 _LedgerTab(cs: cs, tt: tt, ledgerList: _ledger, balance: _balance),
               ],
@@ -384,7 +386,8 @@ class _InfoTab extends StatelessWidget {
   final ColorScheme cs;
   final TextTheme tt;
   final Map<String, dynamic>? profile;
-  const _InfoTab({required this.cs, required this.tt, this.profile});
+  final String employeeId;
+  const _InfoTab({required this.cs, required this.tt, this.profile, required this.employeeId});
 
   @override
   Widget build(BuildContext context) {
@@ -393,6 +396,20 @@ class _InfoTab extends StatelessWidget {
     final designation = profile?['designation'] as String? ?? profile?['role'] as String? ?? '';
     final manager = profile?['manager_name'] as String? ?? 'Not assigned';
     final shiftName = profile?['shift_name'] as String? ?? 'Not assigned';
+
+    final kyc = <String, String>{
+      'PAN Number': profile?['pan_number'] as String? ?? '—',
+      'Aadhaar Number': profile?['aadhaar_number'] as String? ?? '—',
+      'PF / UAN': profile?['pf_number'] as String? ?? '—',
+      'Bank Account': profile?['bank_account_number'] as String? ?? '—',
+      'IFSC': profile?['bank_ifsc'] as String? ?? '—',
+      'UPI ID': profile?['upi_id'] as String? ?? '—',
+      'Emergency Contact': profile?['emergency_contact_name'] as String? ?? '—',
+      'Emergency Phone': profile?['emergency_contact_phone'] as String? ?? '—',
+      'Current Address': profile?['current_address'] as String? ?? '—',
+      'Permanent Address': profile?['permanent_address'] as String? ?? '—',
+      'Health Notes': profile?['health_notes'] as String? ?? '—',
+    };
 
     return ListView(
       padding: const EdgeInsets.fromLTRB(24, 24, 24, 160),
@@ -415,7 +432,342 @@ class _InfoTab extends StatelessWidget {
               'Wage Type': wageType == 'daily' ? 'Daily Wage' : wageType == 'monthly' ? 'Monthly' : wageType,
               'Base Rate': '₹$wageAmount${wageType == 'daily' ? ' / day' : ''}',
             }),
+        _EditorialInfoBlock(
+            cs: cs,
+            tt: tt,
+            title: 'KYC & Identity',
+            data: kyc),
+        const Padding(
+          padding: EdgeInsets.only(top: 8),
+          child: Text('KYC DOCUMENTS',
+              style: TextStyle(fontSize: 11, fontWeight: FontWeight.w800, letterSpacing: 1.0)),
+        ),
+        const SizedBox(height: 16),
+        _DocumentVault(employeeId: employeeId),
+        const SizedBox(height: 8),
       ],
+    );
+  }
+}
+
+class _DocumentVault extends ConsumerStatefulWidget {
+  final String employeeId;
+  const _DocumentVault({required this.employeeId});
+
+  @override
+  ConsumerState<_DocumentVault> createState() => _DocumentVaultState();
+}
+
+class _DocumentVaultState extends ConsumerState<_DocumentVault> {
+  List<Map<String, dynamic>> _docs = [];
+  bool _loading = true;
+  String? _uploadingType;
+
+  static const _types = [
+    ('aadhaar', 'Aadhaar Card', 'fingerprint'),
+    ('pan', 'PAN Card', 'identificationCard'),
+    ('bank', 'Bank Passbook', 'bank'),
+  ];
+
+  @override
+  void initState() {
+    super.initState();
+    _load();
+  }
+
+  Future<void> _load() async {
+    try {
+      final docs = await ref.read(documentServiceProvider).listDocuments(widget.employeeId);
+      if (mounted) {
+        setState(() {
+          _docs = docs.map((d) => d.toJson()).toList();
+          _loading = false;
+        });
+      }
+    } catch (_) {
+      if (mounted) setState(() => _loading = false);
+    }
+  }
+
+  Map<String, dynamic>? _docFor(String type) {
+    for (final d in _docs) {
+      if (d['doc_type'] == type) return d;
+    }
+    return null;
+  }
+
+  Future<void> _upload(String type) async {
+    HapticFeedback.selectionClick();
+    final source = await showModalBottomSheet<String>(
+      context: context,
+      backgroundColor: Theme.of(context).colorScheme.surfaceContainerLowest,
+      builder: (ctx) => SafeArea(
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            ListTile(
+              leading: const Icon(Icons.photo_camera_rounded),
+              title: const Text('Capture with Camera'),
+              onTap: () => Navigator.pop(ctx, 'camera'),
+            ),
+            ListTile(
+              leading: const Icon(Icons.photo_library_rounded),
+              title: const Text('Choose from Gallery'),
+              onTap: () => Navigator.pop(ctx, 'gallery'),
+            ),
+            ListTile(
+              leading: const Icon(Icons.description_rounded),
+              title: const Text('Upload PDF / File'),
+              onTap: () => Navigator.pop(ctx, 'file'),
+            ),
+          ],
+        ),
+      ),
+    );
+    if (source == null || !mounted) return;
+
+    String? path;
+    try {
+      if (source == 'camera' || source == 'gallery') {
+        final picker = ImagePicker();
+        final picked = await picker.pickImage(
+          source: source == 'camera' ? ImageSource.camera : ImageSource.gallery,
+          imageQuality: 70,
+          maxWidth: 1600,
+        );
+        path = picked?.path;
+      } else {
+        final result = await FilePicker.pickFiles(type: FileType.custom, allowedExtensions: ['pdf']);
+        path = result?.files.single.path;
+      }
+    } catch (_) {
+      if (mounted) showError(context, 'Could not pick file');
+      return;
+    }
+    if (path == null || !mounted) return;
+
+    setState(() => _uploadingType = type);
+    try {
+      await ref.read(documentServiceProvider).uploadDocument(
+            employeeId: widget.employeeId,
+            docType: type,
+            filePath: path,
+          );
+      if (mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(const SnackBar(content: Text('Document uploaded')));
+        _load();
+      }
+    } catch (e) {
+      if (mounted) showError(context, e);
+    } finally {
+      if (mounted) setState(() => _uploadingType = null);
+    }
+  }
+
+  Future<void> _view(Map<String, dynamic> doc) async {
+    final url = doc['file_path'] as String? ?? '';
+    if (url.isEmpty) return;
+    await Navigator.of(context).push(
+      MaterialPageRoute(
+        builder: (_) => _DocumentViewerPage(url: url, isPdf: (doc['original_name'] as String? ?? '').toLowerCase().endsWith('.pdf')),
+      ),
+    );
+  }
+
+  Future<void> _delete(String type) async {
+    final confirmed = await showDialog<bool>(
+      context: context,
+      builder: (ctx) => AlertDialog(
+        title: const Text('Delete document'),
+        content: const Text('Remove this document? This cannot be undone.'),
+        actions: [
+          TextButton(onPressed: () => Navigator.pop(ctx, false), child: const Text('Cancel')),
+          FilledButton(
+            onPressed: () => Navigator.pop(ctx, true),
+            style: FilledButton.styleFrom(backgroundColor: Theme.of(ctx).colorScheme.error),
+            child: const Text('Delete'),
+          ),
+        ],
+      ),
+    );
+    if (confirmed != true || !mounted) return;
+    try {
+      await ref.read(documentServiceProvider).deleteDocument(employeeId: widget.employeeId, docType: type);
+      if (mounted) _load();
+    } catch (e) {
+      if (mounted) showError(context, e);
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final cs = Theme.of(context).colorScheme;
+    final tt = Theme.of(context).textTheme;
+
+    if (_loading) {
+      return const Padding(
+        padding: EdgeInsets.symmetric(vertical: 24),
+        child: Center(child: CircularProgressIndicator()),
+      );
+    }
+
+    return Column(
+      children: [
+        for (final (type, label, icon) in _types)
+          _DocumentCard(
+            cs: cs,
+            tt: tt,
+            type: type,
+            label: label,
+            icon: icon,
+            doc: _docFor(type),
+            uploading: _uploadingType == type,
+            onUpload: () => _upload(type),
+            onView: _docFor(type) == null ? null : () => _view(_docFor(type)!),
+            onDelete: _docFor(type) == null ? null : () => _delete(type),
+          ),
+      ],
+    );
+  }
+}
+
+class _DocumentCard extends StatelessWidget {
+  final ColorScheme cs;
+  final TextTheme tt;
+  final String type;
+  final String label;
+  final String icon;
+  final Map<String, dynamic>? doc;
+  final bool uploading;
+  final VoidCallback onUpload;
+  final VoidCallback? onView;
+  final VoidCallback? onDelete;
+
+  const _DocumentCard({
+    required this.cs,
+    required this.tt,
+    required this.type,
+    required this.label,
+    required this.icon,
+    required this.doc,
+    required this.uploading,
+    required this.onUpload,
+    this.onView,
+    this.onDelete,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final isPdf = (doc?['original_name'] as String? ?? '').toLowerCase().endsWith('.pdf');
+    final filePath = doc?['file_path'] as String? ?? '';
+
+    return Container(
+      margin: const EdgeInsets.only(bottom: 16),
+      padding: const EdgeInsets.all(16),
+      decoration: BoxDecoration(
+        color: cs.surface,
+        borderRadius: BorderRadius.circular(16),
+        border: Border.all(color: cs.outlineVariant.withValues(alpha: 0.3)),
+      ),
+      child: Row(
+        children: [
+          if (doc != null && !isPdf)
+            ClipRRect(
+              borderRadius: BorderRadius.circular(12),
+              child: Image.network(
+                filePath,
+                width: 56,
+                height: 56,
+                fit: BoxFit.cover,
+                errorBuilder: (_, _, _) => Icon(_iconFor(icon), size: 28, color: cs.onSurfaceVariant),
+              ),
+            )
+          else
+            Container(
+              width: 56,
+              height: 56,
+              decoration: BoxDecoration(
+                color: cs.primaryContainer.withValues(alpha: 0.4),
+                borderRadius: BorderRadius.circular(12),
+              ),
+              child: Icon(
+                isPdf ? Icons.picture_as_pdf_rounded : _iconFor(icon),
+                size: 28,
+                color: isPdf ? cs.error : cs.primary,
+              ),
+            ),
+          const SizedBox(width: 16),
+          Expanded(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(label, style: tt.titleMedium?.copyWith(fontWeight: FontWeight.w800)),
+                const SizedBox(height: 4),
+                Text(
+                  doc != null ? 'Uploaded' : 'Not uploaded yet',
+                  style: tt.bodySmall?.copyWith(color: cs.onSurfaceVariant),
+                ),
+              ],
+            ),
+          ),
+          if (uploading)
+            const SizedBox(width: 24, height: 24, child: CircularProgressIndicator(strokeWidth: 2))
+          else if (doc != null) ...[
+            IconButton(onPressed: onView, icon: Icon(Icons.visibility_outlined, color: cs.onSurfaceVariant)),
+            IconButton(onPressed: onDelete, icon: Icon(Icons.delete_outline_rounded, color: cs.error)),
+          ] else
+            FilledButton.tonal(onPressed: onUpload, child: const Text('Upload')),
+        ],
+      ),
+    );
+  }
+
+  IconData _iconFor(String name) {
+    switch (name) {
+      case 'fingerprint':
+        return Icons.fingerprint_rounded;
+      case 'identificationCard':
+        return Icons.badge_rounded;
+      default:
+        return Icons.account_balance_rounded;
+    }
+  }
+}
+
+class _DocumentViewerPage extends StatelessWidget {
+  final String url;
+  final bool isPdf;
+  const _DocumentViewerPage({required this.url, required this.isPdf});
+
+  @override
+  Widget build(BuildContext context) {
+    final cs = Theme.of(context).colorScheme;
+    return Scaffold(
+      backgroundColor: Colors.black,
+      appBar: AppBar(
+        backgroundColor: Colors.black,
+        foregroundColor: Colors.white,
+        title: Text(isPdf ? 'Document' : 'Document Preview'),
+      ),
+      body: Center(
+        child: isPdf
+            ? Column(
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  const Icon(Icons.picture_as_pdf_rounded, size: 96, color: Colors.white70),
+                  const SizedBox(height: 16),
+                  Padding(
+                    padding: const EdgeInsets.symmetric(horizontal: 32),
+                    child: Text(url,
+                        textAlign: TextAlign.center,
+                        style: TextStyle(color: cs.onSurface.withValues(alpha: 0.6), fontSize: 12)),
+                  ),
+                ],
+              )
+            : InteractiveViewer(
+                child: Image.network(url, fit: BoxFit.contain),
+              ),
+      ),
     );
   }
 }

--- a/app/lib/models/employee_document_model.dart
+++ b/app/lib/models/employee_document_model.dart
@@ -1,0 +1,40 @@
+class EmployeeDocument {
+  final String id;
+  final String docType;
+  final String filePath;
+  final String? publicId;
+  final String? originalName;
+  final DateTime? uploadedAt;
+
+  EmployeeDocument({
+    required this.id,
+    required this.docType,
+    required this.filePath,
+    this.publicId,
+    this.originalName,
+    this.uploadedAt,
+  });
+
+  factory EmployeeDocument.fromJson(Map<String, dynamic> json) => EmployeeDocument(
+        id: json['id'] as String? ?? '',
+        docType: json['doc_type'] as String? ?? '',
+        filePath: json['file_path'] as String? ?? '',
+        publicId: json['public_id'] as String?,
+        originalName: json['original_name'] as String?,
+        uploadedAt: json['uploaded_at'] != null
+            ? DateTime.tryParse(json['uploaded_at'] as String)
+            : null,
+      );
+
+  bool get isPdf => filePath.toLowerCase().endsWith('.pdf') ||
+      (originalName?.toLowerCase().endsWith('.pdf') ?? false);
+
+  Map<String, dynamic> toJson() => {
+        'id': id,
+        'doc_type': docType,
+        'file_path': filePath,
+        'public_id': publicId,
+        'original_name': originalName,
+        'uploaded_at': uploadedAt?.toIso8601String(),
+      };
+}

--- a/app/lib/models/employee_model.dart
+++ b/app/lib/models/employee_model.dart
@@ -12,6 +12,18 @@ class Employee {
   final bool isActive;
   final String? shiftName;
   final String? managerName;
+  final String? dateOfJoining;
+  final String? panNumber;
+  final String? aadhaarNumber;
+  final String? pfNumber;
+  final String? bankAccountNumber;
+  final String? bankIfsc;
+  final String? upiId;
+  final String? emergencyContactName;
+  final String? emergencyContactPhone;
+  final String? healthNotes;
+  final String? currentAddress;
+  final String? permanentAddress;
 
   Employee({
     required this.id,
@@ -27,6 +39,18 @@ class Employee {
     required this.isActive,
     this.shiftName,
     this.managerName,
+    this.dateOfJoining,
+    this.panNumber,
+    this.aadhaarNumber,
+    this.pfNumber,
+    this.bankAccountNumber,
+    this.bankIfsc,
+    this.upiId,
+    this.emergencyContactName,
+    this.emergencyContactPhone,
+    this.healthNotes,
+    this.currentAddress,
+    this.permanentAddress,
   });
 
   factory Employee.fromJson(Map<String, dynamic> json) => Employee(
@@ -45,6 +69,18 @@ class Employee {
         isActive: json['is_active'] as bool? ?? true,
         shiftName: json['shift_name'] as String?,
         managerName: json['manager_name'] as String?,
+        dateOfJoining: json['date_of_joining'] as String?,
+        panNumber: json['pan_number'] as String?,
+        aadhaarNumber: json['aadhaar_number'] as String?,
+        pfNumber: json['pf_number'] as String?,
+        bankAccountNumber: json['bank_account_number'] as String?,
+        bankIfsc: json['bank_ifsc'] as String?,
+        upiId: json['upi_id'] as String?,
+        emergencyContactName: json['emergency_contact_name'] as String?,
+        emergencyContactPhone: json['emergency_contact_phone'] as String?,
+        healthNotes: json['health_notes'] as String?,
+        currentAddress: json['current_address'] as String?,
+        permanentAddress: json['permanent_address'] as String?,
       );
 
   Map<String, dynamic> toJson() => {

--- a/app/lib/providers/providers.dart
+++ b/app/lib/providers/providers.dart
@@ -18,6 +18,7 @@ import '../services/advance_request_service.dart';
 import '../services/payroll_service.dart';
 import '../services/settings_service.dart';
 import '../services/profile_service.dart';
+import '../services/document_service.dart';
 
 final sessionExpiredProvider = StateProvider<bool>((ref) => false);
 
@@ -150,4 +151,8 @@ final settingsServiceProvider = Provider<SettingsService>((ref) {
 
 final profileServiceProvider = Provider<ProfileService>((ref) {
   return ProfileService(ref.watch(apiClientProvider));
+});
+
+final documentServiceProvider = Provider<DocumentService>((ref) {
+  return DocumentService(ref.watch(apiClientProvider));
 });

--- a/app/lib/services/document_service.dart
+++ b/app/lib/services/document_service.dart
@@ -1,0 +1,33 @@
+import 'package:http/http.dart' as http;
+import '../core/api_client.dart';
+import '../models/employee_document_model.dart';
+
+class DocumentService {
+  final ApiClient _client;
+  DocumentService(this._client);
+
+  Future<List<EmployeeDocument>> listDocuments(String employeeId) async {
+    final res = await _client.get('/api/v1/staff/$employeeId/documents');
+    final list = (res['data'] as List<dynamic>?) ?? [];
+    return list
+        .map((e) => EmployeeDocument.fromJson(e as Map<String, dynamic>))
+        .toList();
+  }
+
+  Future<EmployeeDocument> uploadDocument({
+    required String employeeId,
+    required String docType,
+    required String filePath,
+  }) async {
+    final file = await http.MultipartFile.fromPath('file', filePath);
+    final res = await _client.postMultipart(
+      '/api/v1/staff/$employeeId/documents/$docType',
+      files: [file],
+    );
+    return EmployeeDocument.fromJson(res['data'] as Map<String, dynamic>? ?? {});
+  }
+
+  Future<void> deleteDocument({required String employeeId, required String docType}) async {
+    await _client.delete('/api/v1/staff/$employeeId/documents/$docType');
+  }
+}

--- a/app/pubspec.lock
+++ b/app/pubspec.lock
@@ -65,6 +65,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.19.1"
+  cross_file:
+    dependency: transitive
+    description:
+      name: cross_file
+      sha256: "92c9c43c383bfa1c32079d3bc492d55d6d4318044b7b47edaff8971cbb555c51"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.3.5+4"
   crypto:
     dependency: transitive
     description:
@@ -81,6 +89,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.0.9"
+  dbus:
+    dependency: transitive
+    description:
+      name: dbus
+      sha256: "0ce9b0a839e6dee59a37a623d2fc26a35bbbe6404213e419b0d6411023d62645"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.7.14"
   equatable:
     dependency: transitive
     description:
@@ -113,6 +129,46 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "7.0.1"
+  file_picker:
+    dependency: "direct main"
+    description:
+      name: file_picker
+      sha256: "29cc1fdb20613876cc7afc529738c1c0f11a9ca159b010edad0c566ac330847e"
+      url: "https://pub.dev"
+    source: hosted
+    version: "11.0.3"
+  file_selector_linux:
+    dependency: transitive
+    description:
+      name: file_selector_linux
+      sha256: "2567f398e06ac72dcf2e98a0c95df2a9edd03c2c2e0cacd4780f20cdf56263a0"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.9.4"
+  file_selector_macos:
+    dependency: transitive
+    description:
+      name: file_selector_macos
+      sha256: "5e0bbe9c312416f1787a68259ea1505b52f258c587f12920422671807c4d618a"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.9.5"
+  file_selector_platform_interface:
+    dependency: transitive
+    description:
+      name: file_selector_platform_interface
+      sha256: "35e0bd61ebcdb91a3505813b055b09b79dfdc7d0aee9c09a7ba59ae4bb13dc85"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.7.0"
+  file_selector_windows:
+    dependency: transitive
+    description:
+      name: file_selector_windows
+      sha256: "62197474ae75893a62df75939c777763d39c2bc5f73ce5b88497208bc269abfd"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.9.3+5"
   firebase_auth:
     dependency: "direct main"
     description:
@@ -182,6 +238,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "6.0.0"
+  flutter_plugin_android_lifecycle:
+    dependency: transitive
+    description:
+      name: flutter_plugin_android_lifecycle
+      sha256: "3854fe5e3bff0b113c658f260b90c95dea17c92db0f2addeac2e343dd9969785"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.0.35"
   flutter_riverpod:
     dependency: "direct main"
     description:
@@ -232,6 +296,70 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "4.1.2"
+  image_picker:
+    dependency: "direct main"
+    description:
+      name: image_picker
+      sha256: d8402284df184bc05f4a2210c6c23983b0720f4cd87cbd05c5390a78af602667
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.2.3"
+  image_picker_android:
+    dependency: transitive
+    description:
+      name: image_picker_android
+      sha256: "6f3a1995eafb000333174fae92202622033b0ee7fd917a6cd3730295264df84a"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.8.13+19"
+  image_picker_for_web:
+    dependency: transitive
+    description:
+      name: image_picker_for_web
+      sha256: "66257a3191ab360d23a55c8241c91a6e329d31e94efa7be9cf7a212e65850214"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.1.1"
+  image_picker_ios:
+    dependency: transitive
+    description:
+      name: image_picker_ios
+      sha256: b9c4a438a9ff4f60808c9cf0039b93a42bb6c2211ef6ebb647394b2b3fa84588
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.8.13+6"
+  image_picker_linux:
+    dependency: transitive
+    description:
+      name: image_picker_linux
+      sha256: "1f81c5f2046b9ab724f85523e4af65be1d47b038160a8c8deed909762c308ed4"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.2.2"
+  image_picker_macos:
+    dependency: transitive
+    description:
+      name: image_picker_macos
+      sha256: "86f0f15a309de7e1a552c12df9ce5b59fe927e71385329355aec4776c6a8ec91"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.2.2+1"
+  image_picker_platform_interface:
+    dependency: transitive
+    description:
+      name: image_picker_platform_interface
+      sha256: "567e056716333a1647c64bb6bd873cff7622233a5c3f694be28a583d4715690c"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.11.1"
+  image_picker_windows:
+    dependency: transitive
+    description:
+      name: image_picker_windows
+      sha256: d248c86554a72b5495a31c56f060cf73a41c7ff541689327b1a7dbccc33adfae
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.2.2"
   intl:
     dependency: "direct main"
     description:
@@ -320,6 +448,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.18.0"
+  mime:
+    dependency: transitive
+    description:
+      name: mime
+      sha256: "41a20518f0cb1256669420fdba0cd90d21561e560ac240f26ef8322e45bb7ed6"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.0.0"
   objective_c:
     dependency: transitive
     description:
@@ -392,6 +528,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.3.0"
+  petitparser:
+    dependency: transitive
+    description:
+      name: petitparser
+      sha256: "91bd59303e9f769f108f8df05e371341b15d59e995e6806aefab827b58336675"
+      url: "https://pub.dev"
+    source: hosted
+    version: "7.0.2"
   phosphoricons_flutter:
     dependency: "direct main"
     description:
@@ -613,6 +757,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.1.1"
+  win32:
+    dependency: transitive
+    description:
+      name: win32
+      sha256: d7cb55e04cd34096cd3a79b3330245f54cb96a370a1c27adb3c84b917de8b08e
+      url: "https://pub.dev"
+    source: hosted
+    version: "5.15.0"
   xdg_directories:
     dependency: transitive
     description:
@@ -621,6 +773,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.1.0"
+  xml:
+    dependency: transitive
+    description:
+      name: xml
+      sha256: "971043b3a0d3da28727e40ed3e0b5d18b742fa5a68665cca88e74b7876d5e025"
+      url: "https://pub.dev"
+    source: hosted
+    version: "6.6.1"
   yaml:
     dependency: transitive
     description:

--- a/app/pubspec.yaml
+++ b/app/pubspec.yaml
@@ -44,6 +44,8 @@ dependencies:
   firebase_auth: ^5.5.0
   path_provider: ^2.1.0
   shared_preferences: ^2.5.0
+  image_picker: ^1.2.3
+  file_picker: ^11.0.3
 
 dev_dependencies:
   flutter_test:

--- a/server/.env.example
+++ b/server/.env.example
@@ -21,3 +21,8 @@ TOKEN_TTL=720  # hours; default 720 (30 days)
 # Firebase Auth (Phone Auth)
 FIREBASE_CREDENTIALS_PATH=firebase-credentials.json
 FIREBASE_PROJECT_ID=workforce-9b7de
+
+# Cloudinary (profile photos + KYC document uploads). Leave empty to fall back to local ./uploads.
+CLOUDINARY_CLOUD_NAME=
+CLOUDINARY_API_KEY=
+CLOUDINARY_API_SECRET=

--- a/server/cli/api.go
+++ b/server/cli/api.go
@@ -20,9 +20,9 @@ import (
 
 	"github.com/vivek-app/vivek_app/config"
 	ctrl "github.com/vivek-app/vivek_app/controllers/api/v1"
+	mw "github.com/vivek-app/vivek_app/middlewares"
 	"github.com/vivek-app/vivek_app/repositories"
 	"github.com/vivek-app/vivek_app/services"
-	mw "github.com/vivek-app/vivek_app/middlewares"
 )
 
 func GetAPICommandDef(cfg config.AppConfig, logger *zerolog.Logger) cobra.Command {
@@ -42,10 +42,10 @@ func GetAPICommandDef(cfg config.AppConfig, logger *zerolog.Logger) cobra.Comman
 
 			r := chi.NewRouter()
 
-	r.Use(mw.RequestLogger(logger))
-	r.Use(middleware.Recoverer)
-	r.Use(mw.LimitBodySize(5 << 20))
-	r.Use(cors.Handler(cors.Options{
+			r.Use(mw.RequestLogger(logger))
+			r.Use(middleware.Recoverer)
+			r.Use(mw.LimitBodySize(5 << 20))
+			r.Use(cors.Handler(cors.Options{
 				AllowedOrigins:   []string{cfg.AllowedOrigin},
 				AllowedMethods:   []string{"GET", "POST", "PUT", "DELETE", "OPTIONS"},
 				AllowedHeaders:   []string{"Accept", "Authorization", "Content-Type"},
@@ -53,61 +53,66 @@ func GetAPICommandDef(cfg config.AppConfig, logger *zerolog.Logger) cobra.Comman
 				MaxAge:           300,
 			}))
 
-		r.Get("/health", func(w http.ResponseWriter, r *http.Request) {
-			w.WriteHeader(http.StatusOK)
-			w.Write([]byte("ok"))
-		})
+			r.Get("/health", func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(http.StatusOK)
+				w.Write([]byte("ok"))
+			})
 
-		r.Get("/swagger", func(w http.ResponseWriter, r *http.Request) {
-			http.ServeFile(w, r, "./docs/index.html")
-		})
+			r.Get("/swagger", func(w http.ResponseWriter, r *http.Request) {
+				http.ServeFile(w, r, "./docs/index.html")
+			})
 
-		r.Get("/swagger.json", func(w http.ResponseWriter, r *http.Request) {
-			http.ServeFile(w, r, "./docs/swagger.json")
-		})
+			r.Get("/swagger.json", func(w http.ResponseWriter, r *http.Request) {
+				http.ServeFile(w, r, "./docs/swagger.json")
+			})
 
-		authCtrl, err := ctrl.NewAuthController(querier, logger, cfg)
-			if err != nil {return err}
+			authCtrl, err := ctrl.NewAuthController(querier, logger, cfg)
+			if err != nil {
+				return err
+			}
 			r.Route("/api/v1/auth", func(r chi.Router) {
 				r.Use(mw.RateLimit(10, time.Minute))
 				r.Post("/firebase-login", authCtrl.LoginWithFirebase)
 				r.Post("/register", authCtrl.Register)
 			})
 
-		shiftCtrl := ctrl.NewShiftController(services.NewShiftService(querier), logger, cfg)
-		uploadCtrl := ctrl.NewUploadController(services.NewStaffService(querier), logger, cfg)
-		staffCtrl := ctrl.NewStaffController(services.NewStaffService(querier), logger, cfg)
-		r.Route("/api/v1/staff", func(r chi.Router) {
-			r.Use(mw.AuthMiddleware(cfg))
-			r.Use(mw.TenantMiddleware())
-			r.Get("/", staffCtrl.List)
-			r.Post("/", staffCtrl.Create)
-			r.Get("/{id}", staffCtrl.Get)
-			r.Put("/{id}", staffCtrl.Update)
-			r.Delete("/{id}", staffCtrl.Delete)
-			r.Post("/{id}/upload-photo", uploadCtrl.UploadPhoto)
-			r.Get("/{id}/profile", staffCtrl.Profile)
-			r.Put("/{id}/manager", staffCtrl.AssignManager)
-			r.Put("/{id}/default-shift", shiftCtrl.AssignDefaultShift)
-		})
+			shiftCtrl := ctrl.NewShiftController(services.NewShiftService(querier), logger, cfg)
+			uploadCtrl := ctrl.NewUploadController(services.NewStaffService(querier), logger, cfg)
+			staffCtrl := ctrl.NewStaffController(services.NewStaffService(querier), logger, cfg)
+			r.Route("/api/v1/staff", func(r chi.Router) {
+				r.Use(mw.AuthMiddleware(cfg))
+				r.Use(mw.TenantMiddleware())
+				r.Get("/", staffCtrl.List)
+				r.Post("/", staffCtrl.Create)
+				r.Get("/{id}", staffCtrl.Get)
+				r.Put("/{id}", staffCtrl.Update)
+				r.Delete("/{id}", staffCtrl.Delete)
+				r.Post("/{id}/upload-photo", uploadCtrl.UploadPhoto)
+				r.Get("/{id}/documents", uploadCtrl.ListDocuments)
+				r.Post("/{id}/documents/{type}", uploadCtrl.UploadDocument)
+				r.Delete("/{id}/documents/{type}", uploadCtrl.DeleteDocument)
+				r.Get("/{id}/profile", staffCtrl.Profile)
+				r.Put("/{id}/manager", staffCtrl.AssignManager)
+				r.Put("/{id}/default-shift", shiftCtrl.AssignDefaultShift)
+			})
 
-		meCtrl := ctrl.NewMeController(
-			services.NewStaffService(querier),
-			services.NewAttendanceService(querier),
-			services.NewLedgerService(querier),
-			services.NewPayrollService(querier),
-			services.NewAdvanceRequestService(querier),
-			logger, cfg,
-		)
-		r.Route("/api/v1/me", func(r chi.Router) {
-			r.Use(mw.AuthMiddleware(cfg))
-			r.Use(mw.TenantMiddleware())
-			r.Get("/", meCtrl.Profile)
-			r.Get("/attendance", meCtrl.Attendance)
-			r.Get("/ledger", meCtrl.Ledger)
-			r.Get("/payslip", meCtrl.Payslip)
-			r.Post("/advance-request", meCtrl.RequestAdvance)
-		})
+			meCtrl := ctrl.NewMeController(
+				services.NewStaffService(querier),
+				services.NewAttendanceService(querier),
+				services.NewLedgerService(querier),
+				services.NewPayrollService(querier),
+				services.NewAdvanceRequestService(querier),
+				logger, cfg,
+			)
+			r.Route("/api/v1/me", func(r chi.Router) {
+				r.Use(mw.AuthMiddleware(cfg))
+				r.Use(mw.TenantMiddleware())
+				r.Get("/", meCtrl.Profile)
+				r.Get("/attendance", meCtrl.Attendance)
+				r.Get("/ledger", meCtrl.Ledger)
+				r.Get("/payslip", meCtrl.Payslip)
+				r.Post("/advance-request", meCtrl.RequestAdvance)
+			})
 
 			r.Route("/api/v1/shifts", func(r chi.Router) {
 				r.Use(mw.AuthMiddleware(cfg))

--- a/server/config/main.go
+++ b/server/config/main.go
@@ -10,17 +10,25 @@ import (
 var AllConfig AppConfig
 
 type AppConfig struct {
-	IsDevelopment           bool     `envconfig:"IS_DEVELOPMENT"`
-	Debug                   bool     `envconfig:"DEBUG"`
-	Env                     string   `envconfig:"APP_ENV"`
-	Port                    string   `envconfig:"APP_PORT"`
-	Secret                  string   `envconfig:"JWT_SECRET"`
-	TokenTTL                int      `envconfig:"TOKEN_TTL" default:"72"`
+	IsDevelopment           bool   `envconfig:"IS_DEVELOPMENT"`
+	Debug                   bool   `envconfig:"DEBUG"`
+	Env                     string `envconfig:"APP_ENV"`
+	Port                    string `envconfig:"APP_PORT"`
+	Secret                  string `envconfig:"JWT_SECRET"`
+	TokenTTL                int    `envconfig:"TOKEN_TTL" default:"72"`
 	DB                      DBConfig
 	AllowedOrigin           string `envconfig:"ALLOWED_ORIGIN" default:"*"`
 	FirebaseCredentialsPath string `envconfig:"FIREBASE_CREDENTIALS_PATH"`
 	FirebaseCredBase64      string `envconfig:"FIREBASE_CRED_BASE64"`
 	FirebaseProjectID       string `envconfig:"FIREBASE_PROJECT_ID"`
+	CloudinaryCloudName     string `envconfig:"CLOUDINARY_CLOUD_NAME"`
+	CloudinaryAPIKey        string `envconfig:"CLOUDINARY_API_KEY"`
+	CloudinaryAPISecret     string `envconfig:"CLOUDINARY_API_SECRET"`
+}
+
+// CloudinaryEnabled reports whether Cloudinary upload credentials are configured.
+func (c AppConfig) CloudinaryEnabled() bool {
+	return c.CloudinaryCloudName != "" && c.CloudinaryAPIKey != "" && c.CloudinaryAPISecret != ""
 }
 
 func GetConfig() AppConfig {

--- a/server/controllers/api/v1/staff_controller.go
+++ b/server/controllers/api/v1/staff_controller.go
@@ -32,13 +32,42 @@ func NewStaffController(staffService *services.StaffService, logger *zerolog.Log
 }
 
 type createStaffRequest struct {
-	Name             string `json:"name"`
-	Phone            string `json:"phone"`
-	Designation      string `json:"designation,omitempty"`
-	WageType         string `json:"wage_type"`
-	WageAmount       string `json:"wage_amount"`
-	Role             string `json:"role,omitempty"`
-	DailyTargetUnits *int32 `json:"daily_target_units,omitempty"`
+	Name                  string  `json:"name"`
+	Phone                 string  `json:"phone"`
+	Designation           string  `json:"designation,omitempty"`
+	WageType              string  `json:"wage_type"`
+	WageAmount            string  `json:"wage_amount"`
+	Role                  string  `json:"role,omitempty"`
+	DailyTargetUnits      *int32  `json:"daily_target_units,omitempty"`
+	DateOfJoining         *string `json:"date_of_joining,omitempty"`
+	PanNumber             *string `json:"pan_number,omitempty"`
+	AadhaarNumber         *string `json:"aadhaar_number,omitempty"`
+	PfNumber              *string `json:"pf_number,omitempty"`
+	BankAccountNumber     *string `json:"bank_account_number,omitempty"`
+	BankIfsc              *string `json:"bank_ifsc,omitempty"`
+	UpiID                 *string `json:"upi_id,omitempty"`
+	EmergencyContactName  *string `json:"emergency_contact_name,omitempty"`
+	EmergencyContactPhone *string `json:"emergency_contact_phone,omitempty"`
+	HealthNotes           *string `json:"health_notes,omitempty"`
+	CurrentAddress        *string `json:"current_address,omitempty"`
+	PermanentAddress      *string `json:"permanent_address,omitempty"`
+}
+
+func (r createStaffRequest) kyc() services.EmployeeProfileDetails {
+	return services.EmployeeProfileDetails{
+		DateOfJoining:         r.DateOfJoining,
+		PanNumber:             r.PanNumber,
+		AadhaarNumber:         r.AadhaarNumber,
+		PfNumber:              r.PfNumber,
+		BankAccountNumber:     r.BankAccountNumber,
+		BankIfsc:              r.BankIfsc,
+		UpiID:                 r.UpiID,
+		EmergencyContactName:  r.EmergencyContactName,
+		EmergencyContactPhone: r.EmergencyContactPhone,
+		HealthNotes:           r.HealthNotes,
+		CurrentAddress:        r.CurrentAddress,
+		PermanentAddress:      r.PermanentAddress,
+	}
 }
 
 type assignManagerRequest struct {
@@ -99,7 +128,7 @@ func (ctrl *StaffController) Create(w http.ResponseWriter, r *http.Request) {
 		employeeID = claims.EmployeeID
 	}
 
-	employee, err := ctrl.staffService.CreateEmployee(r.Context(), req.Name, req.Phone, req.Designation, req.WageType, req.WageAmount, req.Role, tenantID, employeeID, req.DailyTargetUnits)
+	employee, err := ctrl.staffService.CreateEmployee(r.Context(), req.Name, req.Phone, req.Designation, req.WageType, req.WageAmount, req.Role, tenantID, employeeID, req.DailyTargetUnits, req.kyc())
 	if err != nil {
 		ctrl.logger.Error().Err(err).Msg("failed to create employee")
 		utils.JSONError(w, http.StatusInternalServerError, "failed to create employee")
@@ -263,7 +292,7 @@ func (ctrl *StaffController) Update(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	employee, err := ctrl.staffService.UpdateEmployee(r.Context(), employeeID, tenantID, req.Name, req.Phone, req.Designation, req.WageType, req.WageAmount, req.Role, req.DailyTargetUnits)
+	employee, err := ctrl.staffService.UpdateEmployee(r.Context(), employeeID, tenantID, req.Name, req.Phone, req.Designation, req.WageType, req.WageAmount, req.Role, req.DailyTargetUnits, req.kyc())
 	if err != nil {
 		ctrl.logger.Error().Err(err).Msg("failed to update employee")
 		utils.JSONError(w, http.StatusInternalServerError, "failed to update employee")

--- a/server/controllers/api/v1/upload_controller.go
+++ b/server/controllers/api/v1/upload_controller.go
@@ -1,7 +1,9 @@
 package v1
 
 import (
+	"bytes"
 	"crypto/rand"
+	"errors"
 	"fmt"
 	"io"
 	"math/big"
@@ -14,6 +16,7 @@ import (
 	"github.com/rs/zerolog"
 	"github.com/vivek-app/vivek_app/config"
 	"github.com/vivek-app/vivek_app/middlewares"
+	"github.com/vivek-app/vivek_app/repositories"
 	"github.com/vivek-app/vivek_app/services"
 	"github.com/vivek-app/vivek_app/utils"
 )
@@ -41,6 +44,30 @@ func NewUploadController(staffService *services.StaffService, logger *zerolog.Lo
 
 const maxUploadSize = 5 << 20
 
+// uploadBytes streams the multipart "file" field into memory (bounded by maxUploadSize).
+func uploadBytes(r *http.Request) ([]byte, string, error) {
+	if err := r.ParseMultipartForm(maxUploadSize); err != nil {
+		return nil, "", fmt.Errorf("file too large or invalid multipart form")
+	}
+	file, header, err := r.FormFile("file")
+	if err != nil {
+		return nil, "", fmt.Errorf("file field is required")
+	}
+	defer file.Close()
+	data, err := io.ReadAll(io.LimitReader(file, maxUploadSize))
+	if err != nil {
+		return nil, "", err
+	}
+	return data, header.Filename, nil
+}
+
+func (c *UploadController) cloudinaryResourceType(ext string) string {
+	if ext == ".pdf" {
+		return "raw"
+	}
+	return "image"
+}
+
 func (c *UploadController) UploadPhoto(w http.ResponseWriter, r *http.Request) {
 	tenantID := middlewares.GetTenantID(r.Context())
 	if tenantID == "" {
@@ -51,43 +78,41 @@ func (c *UploadController) UploadPhoto(w http.ResponseWriter, r *http.Request) {
 	employeeID := chi.URLParam(r, "id")
 
 	r.Body = http.MaxBytesReader(w, r.Body, maxUploadSize)
-	if err := r.ParseMultipartForm(maxUploadSize); err != nil {
-		utils.JSONFail(w, http.StatusBadRequest, "file too large or invalid multipart form")
-		return
-	}
-
-	file, header, err := r.FormFile("file")
+	data, filename, err := uploadBytes(r)
 	if err != nil {
-		utils.JSONFail(w, http.StatusBadRequest, "file field is required")
+		utils.JSONFail(w, http.StatusBadRequest, err.Error())
 		return
 	}
-	defer file.Close()
 
-	ext := filepath.Ext(header.Filename)
+	ext := strings.ToLower(filepath.Ext(filename))
 	if ext != ".jpg" && ext != ".jpeg" && ext != ".png" {
 		utils.JSONFail(w, http.StatusBadRequest, "only .jpg, .jpeg, .png files are allowed")
 		return
 	}
 
-	n, _ := rand.Int(rand.Reader, big.NewInt(1<<62))
-	filename := fmt.Sprintf("%s-%d%s", employeeID, n.Int64(), ext)
-	destPath := filepath.Join(c.uploadDir, filename)
-
-	dst, err := os.Create(destPath)
-	if err != nil {
-		c.logger.Error().Err(err).Msg("failed to create file")
-		utils.JSONError(w, http.StatusInternalServerError, "Failed to save file")
-		return
+	var photoURL string
+	if c.config.CloudinaryEnabled() {
+		cr, upErr := services.UploadToCloudinary(r.Context(),
+			c.config.CloudinaryCloudName, c.config.CloudinaryAPIKey, c.config.CloudinaryAPISecret,
+			"profiles", "profile/"+employeeID, "image", data, filename)
+		if upErr != nil {
+			c.logger.Error().Err(upErr).Msg("cloudinary photo upload failed")
+			utils.JSONError(w, http.StatusInternalServerError, "Failed to upload photo")
+			return
+		}
+		photoURL = cr.SecureURL
+	} else {
+		n, _ := rand.Int(rand.Reader, big.NewInt(1<<62))
+		localName := fmt.Sprintf("%s-%d%s", employeeID, n.Int64(), ext)
+		destPath := filepath.Join(c.uploadDir, localName)
+		if err := c.saveFile(destPath, bytes.NewReader(data)); err != nil {
+			c.logger.Error().Err(err).Msg("failed to save photo")
+			utils.JSONError(w, http.StatusInternalServerError, "Failed to save file")
+			return
+		}
+		photoURL = "/uploads/" + localName
 	}
-	defer dst.Close()
 
-	if _, err := io.Copy(dst, file); err != nil {
-		c.logger.Error().Err(err).Msg("failed to write file")
-		utils.JSONError(w, http.StatusInternalServerError, "Failed to save file")
-		return
-	}
-
-	photoURL := fmt.Sprintf("/uploads/%s", filename)
 	emp, err := c.staffService.UpdatePhotoURL(r.Context(), employeeID, tenantID, photoURL)
 	if err != nil {
 		c.logger.Error().Err(err).Msg("failed to update photo URL")
@@ -99,6 +124,178 @@ func (c *UploadController) UploadPhoto(w http.ResponseWriter, r *http.Request) {
 		"photo_url": photoURL,
 		"employee":  emp,
 	})
+}
+
+// UploadDocument stores a KYC document image or PDF for an employee.
+// One document per doc_type (aadhaar | pan | bank); uploading replaces any existing file.
+func (c *UploadController) UploadDocument(w http.ResponseWriter, r *http.Request) {
+	tenantID := middlewares.GetTenantID(r.Context())
+	if tenantID == "" {
+		utils.JSONFail(w, http.StatusUnauthorized, "Unauthorized")
+		return
+	}
+
+	claims := middlewares.GetClaims(r.Context())
+	if claims != nil && claims.Role == "employee" {
+		utils.JSONFail(w, http.StatusForbidden, "insufficient permissions")
+		return
+	}
+
+	employeeID := chi.URLParam(r, "id")
+	docType := chi.URLParam(r, "type")
+	if docType != "aadhaar" && docType != "pan" && docType != "bank" {
+		utils.JSONFail(w, http.StatusBadRequest, "doc_type must be one of: aadhaar, pan, bank")
+		return
+	}
+
+	r.Body = http.MaxBytesReader(w, r.Body, maxUploadSize)
+	data, filename, err := uploadBytes(r)
+	if err != nil {
+		utils.JSONFail(w, http.StatusBadRequest, err.Error())
+		return
+	}
+
+	ext := strings.ToLower(filepath.Ext(filename))
+	if ext != ".jpg" && ext != ".jpeg" && ext != ".png" && ext != ".pdf" {
+		utils.JSONFail(w, http.StatusBadRequest, "only .jpg, .jpeg, .png, .pdf files are allowed")
+		return
+	}
+
+	existing, getErr := c.staffService.GetDocumentByType(r.Context(), tenantID, employeeID, docType)
+	existingOK := getErr == nil
+
+	var filePath string
+	var publicID *string
+	if c.config.CloudinaryEnabled() {
+		pid := fmt.Sprintf("kyc/%s/%s", employeeID, docType)
+		cr, upErr := services.UploadToCloudinary(r.Context(),
+			c.config.CloudinaryCloudName, c.config.CloudinaryAPIKey, c.config.CloudinaryAPISecret,
+			"kyc/"+employeeID, pid, c.cloudinaryResourceType(ext), data, filename)
+		if upErr != nil {
+			c.logger.Error().Err(upErr).Msg("cloudinary document upload failed")
+			utils.JSONError(w, http.StatusInternalServerError, "Failed to upload document")
+			return
+		}
+		filePath = cr.SecureURL
+		publicID = &cr.PublicID
+	} else {
+		if existingOK && existing.FilePath != "" {
+			c.removeFile(existing.FilePath)
+		}
+		n, _ := rand.Int(rand.Reader, big.NewInt(1<<62))
+		localName := fmt.Sprintf("%s-%s-%d%s", employeeID, docType, n.Int64(), ext)
+		destPath := filepath.Join(c.uploadDir, localName)
+		if err := c.saveFile(destPath, bytes.NewReader(data)); err != nil {
+			c.logger.Error().Err(err).Msg("failed to save document")
+			utils.JSONError(w, http.StatusInternalServerError, "Failed to save file")
+			return
+		}
+		filePath = "/uploads/" + localName
+	}
+
+	originalName := filename
+	doc, err := c.staffService.SaveDocument(r.Context(), tenantID, employeeID, docType, filePath, publicID, &originalName)
+	if err != nil {
+		c.logger.Error().Err(err).Msg("failed to save document record")
+		utils.JSONError(w, http.StatusInternalServerError, "Failed to save document record")
+		return
+	}
+
+	utils.JSONSuccess(w, http.StatusOK, doc)
+}
+
+// ListDocuments returns all stored documents for an employee.
+func (c *UploadController) ListDocuments(w http.ResponseWriter, r *http.Request) {
+	tenantID := middlewares.GetTenantID(r.Context())
+	if tenantID == "" {
+		utils.JSONFail(w, http.StatusUnauthorized, "Unauthorized")
+		return
+	}
+
+	employeeID := chi.URLParam(r, "id")
+	docs, err := c.staffService.ListDocuments(r.Context(), tenantID, employeeID)
+	if err != nil {
+		c.logger.Error().Err(err).Msg("failed to list documents")
+		utils.JSONError(w, http.StatusInternalServerError, "Failed to list documents")
+		return
+	}
+	utils.JSONSuccess(w, http.StatusOK, docs)
+}
+
+// DeleteDocument removes a stored document (record + file).
+func (c *UploadController) DeleteDocument(w http.ResponseWriter, r *http.Request) {
+	tenantID := middlewares.GetTenantID(r.Context())
+	if tenantID == "" {
+		utils.JSONFail(w, http.StatusUnauthorized, "Unauthorized")
+		return
+	}
+
+	claims := middlewares.GetClaims(r.Context())
+	if claims != nil && claims.Role == "employee" {
+		utils.JSONFail(w, http.StatusForbidden, "insufficient permissions")
+		return
+	}
+
+	employeeID := chi.URLParam(r, "id")
+	docType := chi.URLParam(r, "type")
+
+	existing, err := c.staffService.GetDocumentByType(r.Context(), tenantID, employeeID, docType)
+	if err != nil {
+		if errors.Is(err, repositories.ErrNotFound) {
+			utils.JSONFail(w, http.StatusNotFound, "document not found")
+			return
+		}
+		utils.JSONError(w, http.StatusInternalServerError, "Failed to delete document")
+		return
+	}
+
+	if err := c.staffService.DeleteDocument(r.Context(), tenantID, employeeID, docType); err != nil {
+		c.logger.Error().Err(err).Msg("failed to delete document record")
+		utils.JSONError(w, http.StatusInternalServerError, "Failed to delete document")
+		return
+	}
+
+	if c.config.CloudinaryEnabled() {
+		if existing.PublicID != nil {
+			resourceType := "image"
+			if existing.OriginalName != nil {
+				resourceType = c.cloudinaryResourceType(strings.ToLower(filepath.Ext(*existing.OriginalName)))
+			}
+			if err := services.DeleteFromCloudinary(r.Context(),
+				c.config.CloudinaryCloudName, c.config.CloudinaryAPIKey, c.config.CloudinaryAPISecret,
+				*existing.PublicID, resourceType); err != nil {
+				c.logger.Warn().Err(err).Msg("failed to delete cloudinary asset")
+			}
+		}
+	} else {
+		c.removeFile(existing.FilePath)
+	}
+
+	utils.JSONSuccess(w, http.StatusOK, map[string]string{"message": "document deleted"})
+}
+
+func (c *UploadController) saveFile(destPath string, src io.Reader) error {
+	dst, err := os.Create(destPath)
+	if err != nil {
+		return err
+	}
+	defer dst.Close()
+	if _, err := io.Copy(dst, src); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (c *UploadController) removeFile(filePath string) {
+	if filePath == "" {
+		return
+	}
+	filename := filepath.Base(filePath)
+	absPath, _ := filepath.Abs(filepath.Join(c.uploadDir, filename))
+	absDir, _ := filepath.Abs(c.uploadDir)
+	if strings.HasPrefix(absPath, absDir) {
+		_ = os.Remove(absPath)
+	}
 }
 
 func (c *UploadController) ServeFile(w http.ResponseWriter, r *http.Request) {

--- a/server/database/migrations/00019_create_employee_documents_table.sql
+++ b/server/database/migrations/00019_create_employee_documents_table.sql
@@ -1,0 +1,18 @@
+-- +goose Up
+CREATE TABLE employee_documents (
+    id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+    tenant_id uuid NOT NULL REFERENCES tenants(id) ON DELETE CASCADE,
+    employee_id uuid NOT NULL REFERENCES employees(id) ON DELETE CASCADE,
+    doc_type text NOT NULL CHECK (doc_type IN ('aadhaar', 'pan', 'bank')),
+    file_path text NOT NULL,
+    public_id text,
+    original_name text,
+    uploaded_at timestamptz NOT NULL DEFAULT now(),
+    UNIQUE (employee_id, doc_type)
+);
+
+CREATE INDEX idx_employee_documents_tenant_employee ON employee_documents (tenant_id, employee_id);
+
+-- +goose Down
+DROP INDEX IF EXISTS idx_employee_documents_tenant_employee;
+DROP TABLE IF EXISTS employee_documents;

--- a/server/database/test_migrations/001_schema.sql
+++ b/server/database/test_migrations/001_schema.sql
@@ -43,6 +43,20 @@ CREATE TABLE IF NOT EXISTS employees (
 CREATE INDEX IF NOT EXISTS idx_employees_tenant_created ON employees (tenant_id, created_at);
 CREATE INDEX IF NOT EXISTS idx_employees_phone ON employees (phone);
 
+CREATE TABLE IF NOT EXISTS employee_documents (
+    id TEXT PRIMARY KEY,
+    tenant_id TEXT NOT NULL REFERENCES tenants(id) ON DELETE CASCADE,
+    employee_id TEXT NOT NULL REFERENCES employees(id) ON DELETE CASCADE,
+    doc_type TEXT NOT NULL CHECK (doc_type IN ('aadhaar', 'pan', 'bank')),
+    file_path TEXT NOT NULL,
+    public_id TEXT,
+    original_name TEXT,
+    uploaded_at TEXT NOT NULL DEFAULT (datetime('now')),
+    UNIQUE (employee_id, doc_type)
+);
+
+CREATE INDEX IF NOT EXISTS idx_employee_documents_tenant_employee ON employee_documents (tenant_id, employee_id);
+
 CREATE TABLE IF NOT EXISTS shifts (
     id TEXT PRIMARY KEY,
     tenant_id TEXT NOT NULL REFERENCES tenants(id) ON DELETE CASCADE,

--- a/server/mocks/querier.go
+++ b/server/mocks/querier.go
@@ -116,6 +116,21 @@ func (mr *MockQuerierMockRecorder) CreateEmployee(ctx, arg any) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateEmployee", reflect.TypeOf((*MockQuerier)(nil).CreateEmployee), ctx, arg)
 }
 
+// CreateEmployeeDocument mocks base method.
+func (m *MockQuerier) CreateEmployeeDocument(ctx context.Context, arg repositories.CreateEmployeeDocumentParams) (repositories.EmployeeDocument, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "CreateEmployeeDocument", ctx, arg)
+	ret0, _ := ret[0].(repositories.EmployeeDocument)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// CreateEmployeeDocument indicates an expected call of CreateEmployeeDocument.
+func (mr *MockQuerierMockRecorder) CreateEmployeeDocument(ctx, arg any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateEmployeeDocument", reflect.TypeOf((*MockQuerier)(nil).CreateEmployeeDocument), ctx, arg)
+}
+
 // CreateHoliday mocks base method.
 func (m *MockQuerier) CreateHoliday(ctx context.Context, arg repositories.CreateHolidayParams) (repositories.Holiday, error) {
 	m.ctrl.T.Helper()
@@ -189,6 +204,20 @@ func (m *MockQuerier) CreateTenant(ctx context.Context, arg repositories.CreateT
 func (mr *MockQuerierMockRecorder) CreateTenant(ctx, arg any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateTenant", reflect.TypeOf((*MockQuerier)(nil).CreateTenant), ctx, arg)
+}
+
+// DeleteEmployeeDocument mocks base method.
+func (m *MockQuerier) DeleteEmployeeDocument(ctx context.Context, arg repositories.DeleteEmployeeDocumentParams) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "DeleteEmployeeDocument", ctx, arg)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// DeleteEmployeeDocument indicates an expected call of DeleteEmployeeDocument.
+func (mr *MockQuerierMockRecorder) DeleteEmployeeDocument(ctx, arg any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteEmployeeDocument", reflect.TypeOf((*MockQuerier)(nil).DeleteEmployeeDocument), ctx, arg)
 }
 
 // DeleteHoliday mocks base method.
@@ -368,6 +397,21 @@ func (mr *MockQuerierMockRecorder) GetDailyJamaTotal(ctx, tenantID, date any) *g
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetDailyJamaTotal", reflect.TypeOf((*MockQuerier)(nil).GetDailyJamaTotal), ctx, tenantID, date)
 }
 
+// GetEmployeeDocumentByType mocks base method.
+func (m *MockQuerier) GetEmployeeDocumentByType(ctx context.Context, arg repositories.GetEmployeeDocumentByTypeParams) (repositories.EmployeeDocument, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetEmployeeDocumentByType", ctx, arg)
+	ret0, _ := ret[0].(repositories.EmployeeDocument)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetEmployeeDocumentByType indicates an expected call of GetEmployeeDocumentByType.
+func (mr *MockQuerierMockRecorder) GetEmployeeDocumentByType(ctx, arg any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetEmployeeDocumentByType", reflect.TypeOf((*MockQuerier)(nil).GetEmployeeDocumentByType), ctx, arg)
+}
+
 // GetLeavePolicyByTenant mocks base method.
 func (m *MockQuerier) GetLeavePolicyByTenant(ctx context.Context, tenantID string) (repositories.LeavePolicy, error) {
 	m.ctrl.T.Helper()
@@ -501,6 +545,21 @@ func (m *MockQuerier) ListAttendanceByEmployeeMonth(ctx context.Context, arg rep
 func (mr *MockQuerierMockRecorder) ListAttendanceByEmployeeMonth(ctx, arg any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListAttendanceByEmployeeMonth", reflect.TypeOf((*MockQuerier)(nil).ListAttendanceByEmployeeMonth), ctx, arg)
+}
+
+// ListEmployeeDocumentsByEmployee mocks base method.
+func (m *MockQuerier) ListEmployeeDocumentsByEmployee(ctx context.Context, arg repositories.ListEmployeeDocumentsByEmployeeParams) ([]repositories.EmployeeDocument, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ListEmployeeDocumentsByEmployee", ctx, arg)
+	ret0, _ := ret[0].([]repositories.EmployeeDocument)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ListEmployeeDocumentsByEmployee indicates an expected call of ListEmployeeDocumentsByEmployee.
+func (mr *MockQuerierMockRecorder) ListEmployeeDocumentsByEmployee(ctx, arg any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListEmployeeDocumentsByEmployee", reflect.TypeOf((*MockQuerier)(nil).ListEmployeeDocumentsByEmployee), ctx, arg)
 }
 
 // ListEmployeesByTenant mocks base method.

--- a/server/repositories/goqu.go
+++ b/server/repositories/goqu.go
@@ -34,12 +34,12 @@ func (q *GoquQuerier) BulkUpsertAttendance(ctx context.Context, arg BulkUpsertAt
 	var items []Attendance
 	err := q.db.Insert("attendance").Rows(row).
 		OnConflict(goqu.DoUpdate("(tenant_id, employee_id, date)", goqu.Record{
-			"shift_id":                goqu.L("COALESCE(?, shift_id)", excluded("shift_id")),
-			"status":                  excluded("status"),
-			"overtime_hours":          excluded("overtime_hours"),
+			"shift_id":                 goqu.L("COALESCE(?, shift_id)", excluded("shift_id")),
+			"status":                   excluded("status"),
+			"overtime_hours":           excluded("overtime_hours"),
 			"overtime_rate_multiplier": excluded("overtime_rate_multiplier"),
-			"units_produced":          excluded("units_produced"),
-			"updated_at":              goqu.L("now()"),
+			"units_produced":           excluded("units_produced"),
+			"updated_at":               goqu.L("now()"),
 		})).
 		Returning(goqu.Star()).Executor().ScanStructsContext(ctx, &items)
 	return items, err
@@ -71,14 +71,26 @@ func (q *GoquQuerier) CreateAttendance(ctx context.Context, arg CreateAttendance
 func (q *GoquQuerier) CreateEmployee(ctx context.Context, arg CreateEmployeeParams) (Employee, error) {
 	var e Employee
 	rec := goqu.Record{
-		"tenant_id":          arg.TenantID,
-		"name":               arg.Name,
-		"phone":              arg.Phone,
-		"designation":        arg.Designation,
-		"wage_type":          arg.WageType,
-		"wage_amount":        arg.WageAmount,
-		"daily_target_units": arg.DailyTargetUnits,
-		"role":               arg.Role,
+		"tenant_id":               arg.TenantID,
+		"name":                    arg.Name,
+		"phone":                   arg.Phone,
+		"designation":             arg.Designation,
+		"wage_type":               arg.WageType,
+		"wage_amount":             arg.WageAmount,
+		"daily_target_units":      arg.DailyTargetUnits,
+		"date_of_joining":         arg.DateOfJoining,
+		"pan_number":              arg.PanNumber,
+		"aadhaar_number":          arg.AadhaarNumber,
+		"pf_number":               arg.PfNumber,
+		"bank_account_number":     arg.BankAccountNumber,
+		"bank_ifsc":               arg.BankIfsc,
+		"upi_id":                  arg.UpiID,
+		"emergency_contact_name":  arg.EmergencyContactName,
+		"emergency_contact_phone": arg.EmergencyContactPhone,
+		"health_notes":            arg.HealthNotes,
+		"current_address":         arg.CurrentAddress,
+		"permanent_address":       arg.PermanentAddress,
+		"role":                    arg.Role,
 	}
 	found, err := q.db.Insert("employees").Rows(rec).Returning(goqu.Star()).Executor().ScanStructContext(ctx, &e)
 	if err != nil {
@@ -88,6 +100,79 @@ func (q *GoquQuerier) CreateEmployee(ctx context.Context, arg CreateEmployeePara
 		return Employee{}, errors.New("insert did not return a row")
 	}
 	return e, nil
+}
+
+func (q *GoquQuerier) CreateEmployeeDocument(ctx context.Context, arg CreateEmployeeDocumentParams) (EmployeeDocument, error) {
+	var d EmployeeDocument
+	found, err := q.db.Insert("employee_documents").Rows(goqu.Record{
+		"tenant_id":     arg.TenantID,
+		"employee_id":   arg.EmployeeID,
+		"doc_type":      arg.DocType,
+		"file_path":     arg.FilePath,
+		"public_id":     arg.PublicID,
+		"original_name": arg.OriginalName,
+	}).OnConflict(goqu.DoUpdate("", goqu.Record{
+		"file_path":     arg.FilePath,
+		"public_id":     arg.PublicID,
+		"original_name": arg.OriginalName,
+	}).Where(goqu.Ex{
+		"employee_id": arg.EmployeeID,
+		"doc_type":    arg.DocType,
+	})).
+		Returning(goqu.Star()).Executor().ScanStructContext(ctx, &d)
+	if err != nil {
+		return EmployeeDocument{}, err
+	}
+	if !found {
+		return EmployeeDocument{}, errors.New("insert did not return a row")
+	}
+	return d, nil
+}
+
+func (q *GoquQuerier) DeleteEmployeeDocument(ctx context.Context, arg DeleteEmployeeDocumentParams) error {
+	res, err := q.db.Delete("employee_documents").Where(
+		goqu.C("tenant_id").Eq(arg.TenantID),
+		goqu.C("employee_id").Eq(arg.EmployeeID),
+		goqu.C("doc_type").Eq(arg.DocType),
+	).Executor().ExecContext(ctx)
+	if err != nil {
+		return err
+	}
+	rows, err := res.RowsAffected()
+	if err != nil {
+		return err
+	}
+	if rows == 0 {
+		return ErrNotFound
+	}
+	return nil
+}
+
+func (q *GoquQuerier) GetEmployeeDocumentByType(ctx context.Context, arg GetEmployeeDocumentByTypeParams) (EmployeeDocument, error) {
+	var d EmployeeDocument
+	found, err := q.db.Select(goqu.Star()).From("employee_documents").Where(
+		goqu.C("tenant_id").Eq(arg.TenantID),
+		goqu.C("employee_id").Eq(arg.EmployeeID),
+		goqu.C("doc_type").Eq(arg.DocType),
+	).Executor().ScanStructContext(ctx, &d)
+	if err != nil {
+		return EmployeeDocument{}, err
+	}
+	if !found {
+		return EmployeeDocument{}, ErrNotFound
+	}
+	return d, nil
+}
+
+func (q *GoquQuerier) ListEmployeeDocumentsByEmployee(ctx context.Context, arg ListEmployeeDocumentsByEmployeeParams) ([]EmployeeDocument, error) {
+	var docs []EmployeeDocument
+	if err := q.db.Select(goqu.Star()).From("employee_documents").Where(
+		goqu.C("tenant_id").Eq(arg.TenantID),
+		goqu.C("employee_id").Eq(arg.EmployeeID),
+	).Order(goqu.C("uploaded_at").Asc()).Executor().ScanStructsContext(ctx, &docs); err != nil {
+		return nil, err
+	}
+	return docs, nil
 }
 
 func (q *GoquQuerier) CreateHoliday(ctx context.Context, arg CreateHolidayParams) (Holiday, error) {
@@ -692,31 +777,31 @@ func (q *GoquQuerier) UpdateAttendance(ctx context.Context, arg UpdateAttendance
 
 func (q *GoquQuerier) UpdateEmployee(ctx context.Context, arg UpdateEmployeeParams) (Employee, error) {
 	rec := goqu.Record{
-		"name":                     arg.Name,
-		"phone":                    arg.Phone,
-		"designation":              arg.Designation,
-		"wage_type":                arg.WageType,
-		"wage_amount":              arg.WageAmount,
-		"default_shift_id":         arg.DefaultShiftID,
-		"piece_rate_item_name":     arg.PieceRateItemName,
-		"piece_rate_per_unit":      arg.PieceRatePerUnit,
-		"daily_target_units":       arg.DailyTargetUnits,
-		"date_of_joining":          arg.DateOfJoining,
-		"pan_number":               arg.PanNumber,
-		"aadhaar_number":           arg.AadhaarNumber,
-		"pf_number":                arg.PfNumber,
-		"photo_url":                arg.PhotoUrl,
-		"bank_account_number":      arg.BankAccountNumber,
-		"bank_ifsc":                arg.BankIfsc,
-		"upi_id":                   arg.UpiID,
-		"emergency_contact_name":   arg.EmergencyContactName,
-		"emergency_contact_phone":  arg.EmergencyContactPhone,
-		"health_notes":             arg.HealthNotes,
-		"current_address":          arg.CurrentAddress,
-		"permanent_address":        arg.PermanentAddress,
-		"role":                     arg.Role,
-		"is_active":                arg.IsActive,
-		"updated_at":               goqu.L("now()"),
+		"name":                    arg.Name,
+		"phone":                   arg.Phone,
+		"designation":             arg.Designation,
+		"wage_type":               arg.WageType,
+		"wage_amount":             arg.WageAmount,
+		"default_shift_id":        arg.DefaultShiftID,
+		"piece_rate_item_name":    arg.PieceRateItemName,
+		"piece_rate_per_unit":     arg.PieceRatePerUnit,
+		"daily_target_units":      arg.DailyTargetUnits,
+		"date_of_joining":         arg.DateOfJoining,
+		"pan_number":              arg.PanNumber,
+		"aadhaar_number":          arg.AadhaarNumber,
+		"pf_number":               arg.PfNumber,
+		"photo_url":               arg.PhotoUrl,
+		"bank_account_number":     arg.BankAccountNumber,
+		"bank_ifsc":               arg.BankIfsc,
+		"upi_id":                  arg.UpiID,
+		"emergency_contact_name":  arg.EmergencyContactName,
+		"emergency_contact_phone": arg.EmergencyContactPhone,
+		"health_notes":            arg.HealthNotes,
+		"current_address":         arg.CurrentAddress,
+		"permanent_address":       arg.PermanentAddress,
+		"role":                    arg.Role,
+		"is_active":               arg.IsActive,
+		"updated_at":              goqu.L("now()"),
 	}
 	var e Employee
 	found, err := q.db.Update("employees").Set(rec).Where(
@@ -812,10 +897,10 @@ func (q *GoquQuerier) UpdateShift(ctx context.Context, arg UpdateShiftParams) (S
 func (q *GoquQuerier) UpdateSyncEventStatus(ctx context.Context, arg UpdateSyncEventStatusParams) (SyncQueue, error) {
 	var s SyncQueue
 	found, err := q.db.Update("sync_queue").Set(goqu.Record{
-		"status":       arg.Status,
+		"status":        arg.Status,
 		"error_message": arg.ErrorMessage,
-		"retry_count":  goqu.L("CASE WHEN ? = 'failed' THEN retry_count + 1 ELSE retry_count END", arg.Status),
-		"updated_at":   goqu.L("now()"),
+		"retry_count":   goqu.L("CASE WHEN ? = 'failed' THEN retry_count + 1 ELSE retry_count END", arg.Status),
+		"updated_at":    goqu.L("now()"),
 	}).Where(
 		goqu.C("id").Eq(arg.ID),
 		goqu.C("tenant_id").Eq(arg.TenantID),
@@ -868,26 +953,26 @@ func (q *GoquQuerier) GetTenantConfig(ctx context.Context, tenantID string) (Ten
 
 func (q *GoquQuerier) UpsertTenantConfig(ctx context.Context, arg UpsertTenantConfigParams) (TenantConfig, error) {
 	row := goqu.Record{
-		"tenant_id":              arg.TenantID,
-		"ot_trigger":             arg.OTTrigger,
-		"ot_threshold_hours":     arg.OTThresholdHours,
-		"ot_multiplier_default":  arg.OTMultiplierDefault,
-		"ot_rounding":            arg.OTRounding,
-		"wage_basis":             arg.WageBasis,
-		"week_off_paid":          arg.WeekOffPaid,
-		"weekly_offs":            arg.WeeklyOffs,
+		"tenant_id":             arg.TenantID,
+		"ot_trigger":            arg.OTTrigger,
+		"ot_threshold_hours":    arg.OTThresholdHours,
+		"ot_multiplier_default": arg.OTMultiplierDefault,
+		"ot_rounding":           arg.OTRounding,
+		"wage_basis":            arg.WageBasis,
+		"week_off_paid":         arg.WeekOffPaid,
+		"weekly_offs":           arg.WeeklyOffs,
 	}
 	var tc TenantConfig
 	found, err := q.db.Insert("tenant_config").Rows(row).
 		OnConflict(goqu.DoUpdate("tenant_id", goqu.Record{
-			"ot_trigger":             arg.OTTrigger,
-			"ot_threshold_hours":     arg.OTThresholdHours,
-			"ot_multiplier_default":  arg.OTMultiplierDefault,
-			"ot_rounding":            arg.OTRounding,
-			"wage_basis":             arg.WageBasis,
-			"week_off_paid":          arg.WeekOffPaid,
-			"weekly_offs":            arg.WeeklyOffs,
-			"updated_at":             goqu.L("now()"),
+			"ot_trigger":            arg.OTTrigger,
+			"ot_threshold_hours":    arg.OTThresholdHours,
+			"ot_multiplier_default": arg.OTMultiplierDefault,
+			"ot_rounding":           arg.OTRounding,
+			"wage_basis":            arg.WageBasis,
+			"week_off_paid":         arg.WeekOffPaid,
+			"weekly_offs":           arg.WeeklyOffs,
+			"updated_at":            goqu.L("now()"),
 		})).
 		Returning(goqu.Star()).Executor().ScanStructContext(ctx, &tc)
 	if err != nil {

--- a/server/repositories/models.go
+++ b/server/repositories/models.go
@@ -15,17 +15,17 @@ type ActivityLog struct {
 }
 
 type AdvanceRequest struct {
-	ID           string     `json:"id" db:"id"`
-	TenantID     string     `json:"tenant_id" db:"tenant_id"`
-	EmployeeID   string     `json:"employee_id" db:"employee_id"`
-	Amount       float64    `json:"amount" db:"amount"`
-	Status       string     `json:"status" db:"status"`
-	Note         *string    `json:"note" db:"note"`
-	ApprovedBy   *string    `json:"approved_by" db:"approved_by"`
-	DeniedBy     *string    `json:"denied_by" db:"denied_by"`
-	EmployeeName *string    `json:"employee_name"`
-	CreatedAt    time.Time  `json:"created_at" db:"created_at"`
-	UpdatedAt    time.Time  `json:"updated_at" db:"updated_at"`
+	ID           string    `json:"id" db:"id"`
+	TenantID     string    `json:"tenant_id" db:"tenant_id"`
+	EmployeeID   string    `json:"employee_id" db:"employee_id"`
+	Amount       float64   `json:"amount" db:"amount"`
+	Status       string    `json:"status" db:"status"`
+	Note         *string   `json:"note" db:"note"`
+	ApprovedBy   *string   `json:"approved_by" db:"approved_by"`
+	DeniedBy     *string   `json:"denied_by" db:"denied_by"`
+	EmployeeName *string   `json:"employee_name"`
+	CreatedAt    time.Time `json:"created_at" db:"created_at"`
+	UpdatedAt    time.Time `json:"updated_at" db:"updated_at"`
 }
 
 type Attendance struct {
@@ -37,11 +37,11 @@ type Attendance struct {
 	Status                 string     `json:"status" db:"status"`
 	CheckInTime            *time.Time `json:"check_in_time" db:"check_in_time"`
 	CheckOutTime           *time.Time `json:"check_out_time" db:"check_out_time"`
-	OvertimeHours          float64     `json:"overtime_hours" db:"overtime_hours"`
-	OvertimeRateMultiplier float64     `json:"overtime_rate_multiplier" db:"overtime_rate_multiplier"`
-	UnitsProduced          *int32      `json:"units_produced" db:"units_produced"`
-	ComputedWage           *float64    `json:"computed_wage" db:"computed_wage"`
-	IsLocked               bool        `json:"is_locked" db:"is_locked"`
+	OvertimeHours          float64    `json:"overtime_hours" db:"overtime_hours"`
+	OvertimeRateMultiplier float64    `json:"overtime_rate_multiplier" db:"overtime_rate_multiplier"`
+	UnitsProduced          *int32     `json:"units_produced" db:"units_produced"`
+	ComputedWage           *float64   `json:"computed_wage" db:"computed_wage"`
+	IsLocked               bool       `json:"is_locked" db:"is_locked"`
 	EditedBy               *string    `json:"edited_by" db:"edited_by"`
 	EditedAt               *time.Time `json:"edited_at" db:"edited_at"`
 	EmployeeName           *string    `json:"employee_name"`
@@ -50,35 +50,46 @@ type Attendance struct {
 }
 
 type Employee struct {
-	ID                    string     `json:"id" db:"id"`
-	TenantID              string     `json:"tenant_id" db:"tenant_id"`
-	Name                  string     `json:"name" db:"name"`
-	Phone                 string     `json:"phone" db:"phone"`
-	Designation           *string    `json:"designation" db:"designation"`
-	WageType              string     `json:"wage_type" db:"wage_type"`
-	WageAmount            float64    `json:"wage_amount" db:"wage_amount"`
-	DefaultShiftID        *string    `json:"default_shift_id" db:"default_shift_id"`
-	ManagerID             *string    `json:"manager_id" db:"manager_id"`
-	PieceRateItemName     *string    `json:"piece_rate_item_name" db:"piece_rate_item_name"`
-	PieceRatePerUnit      *float64   `json:"piece_rate_per_unit" db:"piece_rate_per_unit"`
-	DailyTargetUnits      *int32     `json:"daily_target_units" db:"daily_target_units"`
-	DateOfJoining         *string    `json:"date_of_joining" db:"date_of_joining"`
-	PanNumber             *string    `json:"pan_number" db:"pan_number"`
-	AadhaarNumber         *string    `json:"aadhaar_number" db:"aadhaar_number"`
-	PfNumber              *string    `json:"pf_number" db:"pf_number"`
-	PhotoUrl              *string    `json:"photo_url" db:"photo_url"`
-	BankAccountNumber     *string    `json:"bank_account_number" db:"bank_account_number"`
-	BankIfsc              *string    `json:"bank_ifsc" db:"bank_ifsc"`
-	UpiID                 *string    `json:"upi_id" db:"upi_id"`
-	EmergencyContactName  *string    `json:"emergency_contact_name" db:"emergency_contact_name"`
-	EmergencyContactPhone *string    `json:"emergency_contact_phone" db:"emergency_contact_phone"`
-	HealthNotes           *string    `json:"health_notes" db:"health_notes"`
-	CurrentAddress        *string    `json:"current_address" db:"current_address"`
-	PermanentAddress      *string    `json:"permanent_address" db:"permanent_address"`
-	Role                  string     `json:"role" db:"role"`
-	IsActive              bool       `json:"is_active" db:"is_active"`
-	CreatedAt             time.Time  `json:"created_at" db:"created_at"`
-	UpdatedAt             time.Time  `json:"updated_at" db:"updated_at"`
+	ID                    string    `json:"id" db:"id"`
+	TenantID              string    `json:"tenant_id" db:"tenant_id"`
+	Name                  string    `json:"name" db:"name"`
+	Phone                 string    `json:"phone" db:"phone"`
+	Designation           *string   `json:"designation" db:"designation"`
+	WageType              string    `json:"wage_type" db:"wage_type"`
+	WageAmount            float64   `json:"wage_amount" db:"wage_amount"`
+	DefaultShiftID        *string   `json:"default_shift_id" db:"default_shift_id"`
+	ManagerID             *string   `json:"manager_id" db:"manager_id"`
+	PieceRateItemName     *string   `json:"piece_rate_item_name" db:"piece_rate_item_name"`
+	PieceRatePerUnit      *float64  `json:"piece_rate_per_unit" db:"piece_rate_per_unit"`
+	DailyTargetUnits      *int32    `json:"daily_target_units" db:"daily_target_units"`
+	DateOfJoining         *string   `json:"date_of_joining" db:"date_of_joining"`
+	PanNumber             *string   `json:"pan_number" db:"pan_number"`
+	AadhaarNumber         *string   `json:"aadhaar_number" db:"aadhaar_number"`
+	PfNumber              *string   `json:"pf_number" db:"pf_number"`
+	PhotoUrl              *string   `json:"photo_url" db:"photo_url"`
+	BankAccountNumber     *string   `json:"bank_account_number" db:"bank_account_number"`
+	BankIfsc              *string   `json:"bank_ifsc" db:"bank_ifsc"`
+	UpiID                 *string   `json:"upi_id" db:"upi_id"`
+	EmergencyContactName  *string   `json:"emergency_contact_name" db:"emergency_contact_name"`
+	EmergencyContactPhone *string   `json:"emergency_contact_phone" db:"emergency_contact_phone"`
+	HealthNotes           *string   `json:"health_notes" db:"health_notes"`
+	CurrentAddress        *string   `json:"current_address" db:"current_address"`
+	PermanentAddress      *string   `json:"permanent_address" db:"permanent_address"`
+	Role                  string    `json:"role" db:"role"`
+	IsActive              bool      `json:"is_active" db:"is_active"`
+	CreatedAt             time.Time `json:"created_at" db:"created_at"`
+	UpdatedAt             time.Time `json:"updated_at" db:"updated_at"`
+}
+
+type EmployeeDocument struct {
+	ID           string    `json:"id" db:"id"`
+	TenantID     string    `json:"tenant_id" db:"tenant_id"`
+	EmployeeID   string    `json:"employee_id" db:"employee_id"`
+	DocType      string    `json:"doc_type" db:"doc_type"`
+	FilePath     string    `json:"file_path" db:"file_path"`
+	PublicID     *string   `json:"public_id" db:"public_id"`
+	OriginalName *string   `json:"original_name" db:"original_name"`
+	UploadedAt   time.Time `json:"uploaded_at" db:"uploaded_at"`
 }
 
 type Holiday struct {

--- a/server/repositories/querier.go
+++ b/server/repositories/querier.go
@@ -48,14 +48,41 @@ type CreateAttendanceParams struct {
 }
 
 type CreateEmployeeParams struct {
-	TenantID         string  `json:"tenant_id"`
-	Name            string  `json:"name"`
-	Phone           string  `json:"phone"`
-	Designation     *string `json:"designation"`
-	WageType        string  `json:"wage_type"`
-	WageAmount      float64 `json:"wage_amount"`
-	DailyTargetUnits *int32 `json:"daily_target_units"`
-	Role            string  `json:"role"`
+	TenantID              string  `json:"tenant_id"`
+	Name                  string  `json:"name"`
+	Phone                 string  `json:"phone"`
+	Designation           *string `json:"designation"`
+	WageType              string  `json:"wage_type"`
+	WageAmount            float64 `json:"wage_amount"`
+	DailyTargetUnits      *int32  `json:"daily_target_units"`
+	DateOfJoining         *string `json:"date_of_joining"`
+	PanNumber             *string `json:"pan_number"`
+	AadhaarNumber         *string `json:"aadhaar_number"`
+	PfNumber              *string `json:"pf_number"`
+	BankAccountNumber     *string `json:"bank_account_number"`
+	BankIfsc              *string `json:"bank_ifsc"`
+	UpiID                 *string `json:"upi_id"`
+	EmergencyContactName  *string `json:"emergency_contact_name"`
+	EmergencyContactPhone *string `json:"emergency_contact_phone"`
+	HealthNotes           *string `json:"health_notes"`
+	CurrentAddress        *string `json:"current_address"`
+	PermanentAddress      *string `json:"permanent_address"`
+	Role                  string  `json:"role"`
+}
+
+type CreateEmployeeDocumentParams struct {
+	TenantID     string  `json:"tenant_id"`
+	EmployeeID   string  `json:"employee_id"`
+	DocType      string  `json:"doc_type"`
+	FilePath     string  `json:"file_path"`
+	PublicID     *string `json:"public_id"`
+	OriginalName *string `json:"original_name"`
+}
+
+type DeleteEmployeeDocumentParams struct {
+	TenantID   string `json:"tenant_id"`
+	EmployeeID string `json:"employee_id"`
+	DocType    string `json:"doc_type"`
 }
 
 type CreateHolidayParams struct {
@@ -244,6 +271,21 @@ type UpdateAttendanceParams struct {
 	ComputedWage           *float64   `json:"computed_wage"`
 }
 
+type FindEmployeeByPhoneOnlyParams struct {
+	Phone string `json:"phone"`
+}
+
+type GetEmployeeDocumentByTypeParams struct {
+	TenantID   string `json:"tenant_id"`
+	EmployeeID string `json:"employee_id"`
+	DocType    string `json:"doc_type"`
+}
+
+type ListEmployeeDocumentsByEmployeeParams struct {
+	TenantID   string `json:"tenant_id"`
+	EmployeeID string `json:"employee_id"`
+}
+
 type UpdateEmployeeParams struct {
 	ID                    string   `json:"id"`
 	Name                  string   `json:"name"`
@@ -340,12 +382,14 @@ type Querier interface {
 	CreateAdvanceRequest(ctx context.Context, arg CreateAdvanceRequestParams) (AdvanceRequest, error)
 	CreateAttendance(ctx context.Context, arg CreateAttendanceParams) (Attendance, error)
 	CreateEmployee(ctx context.Context, arg CreateEmployeeParams) (Employee, error)
+	CreateEmployeeDocument(ctx context.Context, arg CreateEmployeeDocumentParams) (EmployeeDocument, error)
 	CreateHoliday(ctx context.Context, arg CreateHolidayParams) (Holiday, error)
 	CreateLedgerEntry(ctx context.Context, arg CreateLedgerEntryParams) (Ledger, error)
 	CreateShift(ctx context.Context, arg CreateShiftParams) (Shift, error)
 	CreateSyncEvent(ctx context.Context, arg CreateSyncEventParams) (SyncQueue, error)
 	CreateTenant(ctx context.Context, arg CreateTenantParams) (Tenant, error)
 	DeleteHoliday(ctx context.Context, arg DeleteHolidayParams) error
+	DeleteEmployeeDocument(ctx context.Context, arg DeleteEmployeeDocumentParams) error
 	DeleteTenant(ctx context.Context, tenantID string) error
 	DeleteShift(ctx context.Context, arg DeleteShiftParams) error
 	FindEmployeeByID(ctx context.Context, arg FindEmployeeByIDParams) (Employee, error)
@@ -357,6 +401,7 @@ type Querier interface {
 	FindTenantByPhone(ctx context.Context, phone string) (Tenant, error)
 	GetBalanceByEmployee(ctx context.Context, arg GetBalanceByEmployeeParams) (float64, error)
 	GetDailyJamaTotal(ctx context.Context, tenantID string, date string) (float64, error)
+	GetEmployeeDocumentByType(ctx context.Context, arg GetEmployeeDocumentByTypeParams) (EmployeeDocument, error)
 	GetLeavePolicyByTenant(ctx context.Context, tenantID string) (LeavePolicy, error)
 	GetStaffProfile(ctx context.Context, arg GetStaffProfileParams) (StaffProfile, error)
 	GetTenantConfig(ctx context.Context, tenantID string) (TenantConfig, error)
@@ -367,6 +412,7 @@ type Querier interface {
 	ListAttendanceByDateRange(ctx context.Context, arg ListAttendanceByDateRangeParams) ([]Attendance, error)
 	ListAttendanceByEmployeeMonth(ctx context.Context, arg ListAttendanceByEmployeeMonthParams) ([]Attendance, error)
 	ListEmployeesByTenant(ctx context.Context, arg ListEmployeesByTenantParams) ([]Employee, error)
+	ListEmployeeDocumentsByEmployee(ctx context.Context, arg ListEmployeeDocumentsByEmployeeParams) ([]EmployeeDocument, error)
 	ListHolidaysByTenant(ctx context.Context, arg ListHolidaysByTenantParams) ([]Holiday, error)
 	ListLedgerByEmployeeMonth(ctx context.Context, arg ListLedgerByEmployeeMonthParams) ([]Ledger, error)
 	ListLedgerByTenant(ctx context.Context, arg ListLedgerByTenantParams) ([]Ledger, error)

--- a/server/services/cloudinary.go
+++ b/server/services/cloudinary.go
@@ -1,0 +1,160 @@
+package services
+
+import (
+	"bytes"
+	"context"
+	"crypto/sha1"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"io"
+	"mime/multipart"
+	"net/http"
+	"sort"
+	"strings"
+	"time"
+)
+
+const cloudinaryBaseURL = "https://api.cloudinary.com/v1_1"
+
+type CloudinaryResult struct {
+	SecureURL string `json:"secure_url"`
+	PublicID  string `json:"public_id"`
+}
+
+func cloudinarySignature(params map[string]string, apiSecret string) string {
+	keys := make([]string, 0, len(params))
+	for k := range params {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	var sb strings.Builder
+	for i, k := range keys {
+		if i > 0 {
+			sb.WriteString("&")
+		}
+		sb.WriteString(k)
+		sb.WriteString("=")
+		sb.WriteString(params[k])
+	}
+	sb.WriteString(apiSecret)
+	sum := sha1.Sum([]byte(sb.String()))
+	return hex.EncodeToString(sum[:])
+}
+
+// UploadToCloudinary uploads raw bytes to Cloudinary and returns the secure URL and public id.
+// resourceType must be one of: image, raw, auto. A deterministic publicID lets re-uploads overwrite.
+func UploadToCloudinary(ctx context.Context, cloudName, apiKey, apiSecret, folder, publicID, resourceType string, fileBytes []byte, filename string) (*CloudinaryResult, error) {
+	if resourceType == "" {
+		resourceType = "auto"
+	}
+	timestamp := fmt.Sprintf("%d", time.Now().Unix())
+
+	params := map[string]string{
+		"timestamp": timestamp,
+		"folder":    folder,
+		"overwrite": "true",
+	}
+	if publicID != "" {
+		params["public_id"] = publicID
+	}
+	signature := cloudinarySignature(params, apiSecret)
+
+	var buf bytes.Buffer
+	mp := multipart.NewWriter(&buf)
+	writeField := func(k, v string) error { return mp.WriteField(k, v) }
+	if err := writeField("timestamp", timestamp); err != nil {
+		return nil, err
+	}
+	if err := writeField("folder", folder); err != nil {
+		return nil, err
+	}
+	if err := writeField("overwrite", "true"); err != nil {
+		return nil, err
+	}
+	if publicID != "" {
+		if err := writeField("public_id", publicID); err != nil {
+			return nil, err
+		}
+	}
+	if err := writeField("api_key", apiKey); err != nil {
+		return nil, err
+	}
+	if err := writeField("signature", signature); err != nil {
+		return nil, err
+	}
+	fw, err := mp.CreateFormFile("file", filename)
+	if err != nil {
+		return nil, err
+	}
+	if _, err := fw.Write(fileBytes); err != nil {
+		return nil, err
+	}
+	if err := mp.Close(); err != nil {
+		return nil, err
+	}
+
+	endpoint := fmt.Sprintf("%s/%s/%s/upload", cloudinaryBaseURL, cloudName, resourceType)
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, endpoint, &buf)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Content-Type", mp.FormDataContentType())
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("cloudinary upload request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, err
+	}
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return nil, fmt.Errorf("cloudinary upload failed (%d): %s", resp.StatusCode, string(body))
+	}
+
+	var result CloudinaryResult
+	if err := json.Unmarshal(body, &result); err != nil {
+		return nil, fmt.Errorf("cloudinary upload response: %w", err)
+	}
+	return &result, nil
+}
+
+// DeleteFromCloudinary removes an asset by public id.
+// resourceType must be one of: image, raw.
+func DeleteFromCloudinary(ctx context.Context, cloudName, apiKey, apiSecret, publicID, resourceType string) error {
+	if publicID == "" {
+		return nil
+	}
+	if resourceType == "" {
+		resourceType = "image"
+	}
+	timestamp := fmt.Sprintf("%d", time.Now().Unix())
+	params := map[string]string{
+		"timestamp": timestamp,
+		"public_id": publicID,
+	}
+	signature := cloudinarySignature(params, apiSecret)
+
+	form := fmt.Sprintf("timestamp=%s&public_id=%s&api_key=%s&signature=%s",
+		timestamp, publicID, apiKey, signature)
+	endpoint := fmt.Sprintf("%s/%s/%s/destroy", cloudinaryBaseURL, cloudName, resourceType)
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, endpoint, strings.NewReader(form))
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("cloudinary destroy request: %w", err)
+	}
+	defer resp.Body.Close()
+	body, _ := io.ReadAll(resp.Body)
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return fmt.Errorf("cloudinary destroy failed (%d): %s", resp.StatusCode, string(body))
+	}
+	return nil
+}

--- a/server/services/staff_service.go
+++ b/server/services/staff_service.go
@@ -16,7 +16,24 @@ func NewStaffService(querier repositories.Querier) *StaffService {
 	return &StaffService{querier: querier}
 }
 
-func (s *StaffService) CreateEmployee(ctx context.Context, name, phone, designation, wageType, wageAmount, role, tenantID, employeeID string, dailyTargetUnits *int32) (repositories.Employee, error) {
+// EmployeeProfileDetails carries optional KYC/personal fields for an employee.
+// On update, nil fields leave the existing value untouched.
+type EmployeeProfileDetails struct {
+	DateOfJoining         *string
+	PanNumber             *string
+	AadhaarNumber         *string
+	PfNumber              *string
+	BankAccountNumber     *string
+	BankIfsc              *string
+	UpiID                 *string
+	EmergencyContactName  *string
+	EmergencyContactPhone *string
+	HealthNotes           *string
+	CurrentAddress        *string
+	PermanentAddress      *string
+}
+
+func (s *StaffService) CreateEmployee(ctx context.Context, name, phone, designation, wageType, wageAmount, role, tenantID, employeeID string, dailyTargetUnits *int32, kyc EmployeeProfileDetails) (repositories.Employee, error) {
 	wageAmt, err := strconv.ParseFloat(wageAmount, 64)
 	if err != nil {
 		return repositories.Employee{}, fmt.Errorf("invalid wage_amount: %w", err)
@@ -29,14 +46,26 @@ func (s *StaffService) CreateEmployee(ctx context.Context, name, phone, designat
 		role = "employee"
 	}
 	emp, err := s.querier.CreateEmployee(ctx, repositories.CreateEmployeeParams{
-		TenantID:         tenantID,
-		Name:             name,
-		Phone:            phone,
-		Designation:      desig,
-		WageType:         wageType,
-		WageAmount:       wageAmt,
-		DailyTargetUnits: dailyTargetUnits,
-		Role:             role,
+		TenantID:              tenantID,
+		Name:                  name,
+		Phone:                 phone,
+		Designation:           desig,
+		WageType:              wageType,
+		WageAmount:            wageAmt,
+		DailyTargetUnits:      dailyTargetUnits,
+		DateOfJoining:         kyc.DateOfJoining,
+		PanNumber:             kyc.PanNumber,
+		AadhaarNumber:         kyc.AadhaarNumber,
+		PfNumber:              kyc.PfNumber,
+		BankAccountNumber:     kyc.BankAccountNumber,
+		BankIfsc:              kyc.BankIfsc,
+		UpiID:                 kyc.UpiID,
+		EmergencyContactName:  kyc.EmergencyContactName,
+		EmergencyContactPhone: kyc.EmergencyContactPhone,
+		HealthNotes:           kyc.HealthNotes,
+		CurrentAddress:        kyc.CurrentAddress,
+		PermanentAddress:      kyc.PermanentAddress,
+		Role:                  role,
 	})
 	if err == nil {
 		logActivity(ctx, s.querier, tenantID, employeeID, "created_employee", "employee", &emp.ID, nil)
@@ -51,7 +80,7 @@ func (s *StaffService) GetEmployee(ctx context.Context, employeeID, tenantID str
 	})
 }
 
-func (s *StaffService) UpdateEmployee(ctx context.Context, employeeID, tenantID, name, phone, designation, wageType, wageAmount, role string, dailyTargetUnits *int32) (repositories.Employee, error) {
+func (s *StaffService) UpdateEmployee(ctx context.Context, employeeID, tenantID, name, phone, designation, wageType, wageAmount, role string, dailyTargetUnits *int32, kyc EmployeeProfileDetails) (repositories.Employee, error) {
 	existing, err := s.querier.FindEmployeeByID(ctx, repositories.FindEmployeeByIDParams{
 		ID:       employeeID,
 		TenantID: tenantID,
@@ -89,6 +118,55 @@ func (s *StaffService) UpdateEmployee(ctx context.Context, employeeID, tenantID,
 		role = existing.Role
 	}
 
+	dateOfJoining := existing.DateOfJoining
+	if kyc.DateOfJoining != nil {
+		dateOfJoining = kyc.DateOfJoining
+	}
+	panNumber := existing.PanNumber
+	if kyc.PanNumber != nil {
+		panNumber = kyc.PanNumber
+	}
+	aadhaarNumber := existing.AadhaarNumber
+	if kyc.AadhaarNumber != nil {
+		aadhaarNumber = kyc.AadhaarNumber
+	}
+	pfNumber := existing.PfNumber
+	if kyc.PfNumber != nil {
+		pfNumber = kyc.PfNumber
+	}
+	bankAccountNumber := existing.BankAccountNumber
+	if kyc.BankAccountNumber != nil {
+		bankAccountNumber = kyc.BankAccountNumber
+	}
+	bankIfsc := existing.BankIfsc
+	if kyc.BankIfsc != nil {
+		bankIfsc = kyc.BankIfsc
+	}
+	upiID := existing.UpiID
+	if kyc.UpiID != nil {
+		upiID = kyc.UpiID
+	}
+	emergencyContactName := existing.EmergencyContactName
+	if kyc.EmergencyContactName != nil {
+		emergencyContactName = kyc.EmergencyContactName
+	}
+	emergencyContactPhone := existing.EmergencyContactPhone
+	if kyc.EmergencyContactPhone != nil {
+		emergencyContactPhone = kyc.EmergencyContactPhone
+	}
+	healthNotes := existing.HealthNotes
+	if kyc.HealthNotes != nil {
+		healthNotes = kyc.HealthNotes
+	}
+	currentAddress := existing.CurrentAddress
+	if kyc.CurrentAddress != nil {
+		currentAddress = kyc.CurrentAddress
+	}
+	permanentAddress := existing.PermanentAddress
+	if kyc.PermanentAddress != nil {
+		permanentAddress = kyc.PermanentAddress
+	}
+
 	emp, err := s.querier.UpdateEmployee(ctx, repositories.UpdateEmployeeParams{
 		ID:                    employeeID,
 		TenantID:              tenantID,
@@ -101,19 +179,19 @@ func (s *StaffService) UpdateEmployee(ctx context.Context, employeeID, tenantID,
 		PieceRateItemName:     existing.PieceRateItemName,
 		PieceRatePerUnit:      existing.PieceRatePerUnit,
 		DailyTargetUnits:      dailyTargetUnits,
-		DateOfJoining:         existing.DateOfJoining,
-		PanNumber:             existing.PanNumber,
-		AadhaarNumber:         existing.AadhaarNumber,
-		PfNumber:              existing.PfNumber,
+		DateOfJoining:         dateOfJoining,
+		PanNumber:             panNumber,
+		AadhaarNumber:         aadhaarNumber,
+		PfNumber:              pfNumber,
 		PhotoUrl:              existing.PhotoUrl,
-		BankAccountNumber:     existing.BankAccountNumber,
-		BankIfsc:              existing.BankIfsc,
-		UpiID:                 existing.UpiID,
-		EmergencyContactName:  existing.EmergencyContactName,
-		EmergencyContactPhone: existing.EmergencyContactPhone,
-		HealthNotes:           existing.HealthNotes,
-		CurrentAddress:        existing.CurrentAddress,
-		PermanentAddress:      existing.PermanentAddress,
+		BankAccountNumber:     bankAccountNumber,
+		BankIfsc:              bankIfsc,
+		UpiID:                 upiID,
+		EmergencyContactName:  emergencyContactName,
+		EmergencyContactPhone: emergencyContactPhone,
+		HealthNotes:           healthNotes,
+		CurrentAddress:        currentAddress,
+		PermanentAddress:      permanentAddress,
 		Role:                  role,
 		IsActive:              existing.IsActive,
 	})
@@ -146,6 +224,40 @@ func (s *StaffService) UpdatePhotoURL(ctx context.Context, employeeID, tenantID,
 		ID:       employeeID,
 		TenantID: tenantID,
 		PhotoURL: photoURL,
+	})
+}
+
+func (s *StaffService) SaveDocument(ctx context.Context, tenantID, employeeID, docType, filePath string, publicID *string, originalName *string) (repositories.EmployeeDocument, error) {
+	return s.querier.CreateEmployeeDocument(ctx, repositories.CreateEmployeeDocumentParams{
+		TenantID:     tenantID,
+		EmployeeID:   employeeID,
+		DocType:      docType,
+		FilePath:     filePath,
+		PublicID:     publicID,
+		OriginalName: originalName,
+	})
+}
+
+func (s *StaffService) GetDocumentByType(ctx context.Context, tenantID, employeeID, docType string) (repositories.EmployeeDocument, error) {
+	return s.querier.GetEmployeeDocumentByType(ctx, repositories.GetEmployeeDocumentByTypeParams{
+		TenantID:   tenantID,
+		EmployeeID: employeeID,
+		DocType:    docType,
+	})
+}
+
+func (s *StaffService) ListDocuments(ctx context.Context, tenantID, employeeID string) ([]repositories.EmployeeDocument, error) {
+	return s.querier.ListEmployeeDocumentsByEmployee(ctx, repositories.ListEmployeeDocumentsByEmployeeParams{
+		TenantID:   tenantID,
+		EmployeeID: employeeID,
+	})
+}
+
+func (s *StaffService) DeleteDocument(ctx context.Context, tenantID, employeeID, docType string) error {
+	return s.querier.DeleteEmployeeDocument(ctx, repositories.DeleteEmployeeDocumentParams{
+		TenantID:   tenantID,
+		EmployeeID: employeeID,
+		DocType:    docType,
 	})
 }
 

--- a/server/services/staff_service_test.go
+++ b/server/services/staff_service_test.go
@@ -18,9 +18,9 @@ func TestStaffService_CreateEmployee(t *testing.T) {
 	svc := NewStaffService(mockQuerier)
 
 	expected := repositories.Employee{
-		Name:      "John Doe",
-		Phone:     "+91-9876543210",
-		WageType:  "daily",
+		Name:       "John Doe",
+		Phone:      "+91-9876543210",
+		WageType:   "daily",
 		WageAmount: 500,
 	}
 
@@ -31,7 +31,7 @@ func TestStaffService_CreateEmployee(t *testing.T) {
 		CreateActivityLog(gomock.Any(), gomock.Any()).
 		Return(repositories.ActivityLog{}, nil)
 
-	created, err := svc.CreateEmployee(context.Background(), "John Doe", "+91-9876543210", "", "daily", "500", "employee", "00000000-0000-0000-0000-000000000001", "00000000-0000-0000-0000-000000000002", nil)
+	created, err := svc.CreateEmployee(context.Background(), "John Doe", "+91-9876543210", "", "daily", "500", "employee", "00000000-0000-0000-0000-000000000001", "00000000-0000-0000-0000-000000000002", nil, EmployeeProfileDetails{})
 	if err != nil {
 		t.Fatalf("CreateEmployee failed: %v", err)
 	}
@@ -71,7 +71,7 @@ func TestStaffService_CreateEmployee_DBError(t *testing.T) {
 		CreateEmployee(gomock.Any(), gomock.Any()).
 		Return(repositories.Employee{}, errors.New("db error"))
 
-	_, err := svc.CreateEmployee(context.Background(), "John", "+91-9876543210", "", "daily", "500", "employee", "00000000-0000-0000-0000-000000000001", "00000000-0000-0000-0000-000000000002", nil)
+	_, err := svc.CreateEmployee(context.Background(), "John", "+91-9876543210", "", "daily", "500", "employee", "00000000-0000-0000-0000-000000000001", "00000000-0000-0000-0000-000000000002", nil, EmployeeProfileDetails{})
 	if err == nil {
 		t.Fatal("expected error, got nil")
 	}
@@ -112,7 +112,7 @@ func TestStaffService_UpdateEmployee(t *testing.T) {
 		CreateActivityLog(gomock.Any(), gomock.Any()).
 		Return(repositories.ActivityLog{}, nil)
 
-	emp, err := svc.UpdateEmployee(context.Background(), "00000000-0000-0000-0000-000000000002", "00000000-0000-0000-0000-000000000001", "Updated", "+91-9876543210", "Manager", "monthly", "1000", "manager", nil)
+	emp, err := svc.UpdateEmployee(context.Background(), "00000000-0000-0000-0000-000000000002", "00000000-0000-0000-0000-000000000001", "Updated", "+91-9876543210", "Manager", "monthly", "1000", "manager", nil, EmployeeProfileDetails{})
 	if err != nil {
 		t.Fatalf("UpdateEmployee failed: %v", err)
 	}
@@ -135,7 +135,7 @@ func TestStaffService_UpdateEmployee_DBError(t *testing.T) {
 		UpdateEmployee(gomock.Any(), gomock.Any()).
 		Return(repositories.Employee{}, errors.New("db error"))
 
-	_, err := svc.UpdateEmployee(context.Background(), "00000000-0000-0000-0000-000000000002", "00000000-0000-0000-0000-000000000001", "Updated", "+91-9876543210", "Manager", "monthly", "1000", "manager", nil)
+	_, err := svc.UpdateEmployee(context.Background(), "00000000-0000-0000-0000-000000000002", "00000000-0000-0000-0000-000000000001", "Updated", "+91-9876543210", "Manager", "monthly", "1000", "manager", nil, EmployeeProfileDetails{})
 	if err == nil {
 		t.Fatal("expected error, got nil")
 	}


### PR DESCRIPTION
KYC + Cloudinary work is complete and green (backend go test passes, dart analyze shows only the 5 pre-existing info lints). Summary:
Cloudinary config
- server/config/main.go — added CloudinaryCloudName/APIKey/APISecret (+ CloudinaryEnabled()), loaded from env.
- Real creds written to gitignored server/.env; placeholders in server/.env.example.
Backend
- services/cloudinary.go — signed upload + destroy helpers (SHA1 signature, image/raw resource types, deterministic public_ids so re-uploads overwrite).
- upload_controller.go — photos upload to profiles/; KYC docs to kyc/{employeeID}/ as aadhaar/pan/bank slots (jpg/jpeg/png/pdf, one per slot, replaces). Delete destroys the Cloudinary asset. Local ./uploads retained as fallback when Cloudinary isn't configured.
- Migration 00019 + repo layer (employee_documents table with public_id), routes wired, test schema updated, mocks regenerated.
- Create/Update employee now accept the 12 KYC fields (PAN, Aadhaar, PF, bank, UPI, emergency, addresses, health, DOJ).
Frontend
- ApiClient.postMultipart(); new DocumentService + EmployeeDocument model.
- Profile Info & KYC tab now shows KYC identity data plus a 3-card document vault (Aadhaar/PAN/Bank Passbook) with camera/gallery/PDF picker, thumbnails, view, and delete.
- Add/Edit Employee form gained "KYC & Financial" and "Emergency & Address" sections (incl. date-of-joining picker).
- Added image_picker + file_picker deps and iOS permission strings.