### PR TITLE
fix: remove redundant parens from goqu DoUpdate to fix SQL syntax error

### DIFF
--- a/server/repositories/goqu.go
+++ b/server/repositories/goqu.go
@@ -181,7 +181,7 @@ func (q *GoquQuerier) CreateAttendance(ctx context.Context, arg CreateAttendance
 	}
 	excluded := func(col string) exp.Expression { return goqu.L("EXCLUDED." + col) }
 	found, err := q.db.Insert("attendance").Rows(row).
-		OnConflict(goqu.DoUpdate("(tenant_id, employee_id, date)", goqu.Record{
+		OnConflict(goqu.DoUpdate("tenant_id, employee_id, date", goqu.Record{
 			"shift_id":                 excluded("shift_id"),
 			"status":                   excluded("status"),
 			"check_in_time":            excluded("check_in_time"),


### PR DESCRIPTION
goqu.DoUpdate auto-wraps the column string in parentheses, so passing "(tenant_id, employee_id, date)" produced invalid SQL ON CONFLICT ((tenant_id, employee_id, date)). Fixed to "tenant_id, employee_id, date".